### PR TITLE
Config path to Conan exe, confirm dialog before wiping the Cache, other improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea/*
 *.iml
+.gradle
+build/

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 }
 
 plugins {
-    id "org.jetbrains.intellij" version "0.3.1"
+    id "org.jetbrains.intellij" version "0.4.8"
     id "de.undercouch.download" version "3.4.2"
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Wed Apr 17 15:23:16 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/src/main/java/conan/actions/ActionUtils.java
+++ b/src/main/java/conan/actions/ActionUtils.java
@@ -23,7 +23,7 @@ import java.util.Map;
  */
 class ActionUtils {
 
-    static boolean isInstalled(Project project){
+    static boolean isConanInstalled(Project project){
         IsInstalledCommand isInstalled = new IsInstalledCommand(project);
         isInstalled.run();
         return isInstalled.isInstalled();
@@ -38,7 +38,7 @@ class ActionUtils {
      */
     static void runInstall(Project project, Component component, boolean update) {
 
-        if(!isInstalled(project)){
+        if(!isConanInstalled(project)){
             return;
         }
 
@@ -63,7 +63,7 @@ class ActionUtils {
      */
     private static void matchProfilesAndInstall(Project project, Component component, boolean update) {
 
-        if(!isInstalled(project)){
+        if(!isConanInstalled(project)){
             return;
         }
 

--- a/src/main/java/conan/actions/ActionUtils.java
+++ b/src/main/java/conan/actions/ActionUtils.java
@@ -5,6 +5,7 @@ import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.project.Project;
 import conan.commands.Install;
+import conan.commands.IsInstalledCommand;
 import conan.commands.Version;
 import conan.persistency.settings.ConanProjectSettings;
 import conan.profiles.CMakeProfile;
@@ -22,6 +23,12 @@ import java.util.Map;
  */
 class ActionUtils {
 
+    static boolean isInstalled(Project project){
+        IsInstalledCommand isInstalled = new IsInstalledCommand(project);
+        isInstalled.run();
+        return isInstalled.isInstalled();
+    }
+
     /**
      * Run conan install for the selected Conan profile.
      *
@@ -30,7 +37,11 @@ class ActionUtils {
      * @param update    true if it's update and install action.
      */
     static void runInstall(Project project, Component component, boolean update) {
-        new Version(project).run();
+
+        if(!isInstalled(project)){
+            return;
+        }
+
         FileDocumentManager.getInstance().saveAllDocuments();
         ConanToolWindow conanToolWindow = ServiceManager.getService(project, ConanToolWindow.class);
         ConanProfile conanProfile = new ConanProfile(conanToolWindow.getSelectedTab());
@@ -51,6 +62,11 @@ class ActionUtils {
      * @param update    true if it's update and install action.
      */
     private static void matchProfilesAndInstall(Project project, Component component, boolean update) {
+
+        if(!isInstalled(project)){
+            return;
+        }
+
         ProfileMatcher.showDialog(project, component);
         ConanProjectSettings conanProjectSettings = ConanProjectSettings.getInstance(project);
         Map<CMakeProfile, ConanProfile> profileMapping = conanProjectSettings.getProfileMapping();

--- a/src/main/java/conan/actions/ActionUtils.java
+++ b/src/main/java/conan/actions/ActionUtils.java
@@ -6,7 +6,6 @@ import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.project.Project;
 import conan.commands.Install;
 import conan.commands.IsInstalledCommand;
-import conan.commands.Version;
 import conan.persistency.settings.ConanProjectSettings;
 import conan.profiles.CMakeProfile;
 import conan.profiles.ConanProfile;
@@ -37,11 +36,9 @@ class ActionUtils {
      * @param update    true if it's update and install action.
      */
     static void runInstall(Project project, Component component, boolean update) {
-
-        if(!isConanInstalled(project)){
+        if (!isConanInstalled(project)){
             return;
         }
-
         FileDocumentManager.getInstance().saveAllDocuments();
         ConanToolWindow conanToolWindow = ServiceManager.getService(project, ConanToolWindow.class);
         ConanProfile conanProfile = new ConanProfile(conanToolWindow.getSelectedTab());
@@ -62,11 +59,9 @@ class ActionUtils {
      * @param update    true if it's update and install action.
      */
     private static void matchProfilesAndInstall(Project project, Component component, boolean update) {
-
-        if(!isConanInstalled(project)){
+        if (!isConanInstalled(project)){
             return;
         }
-
         ProfileMatcher.showDialog(project, component);
         ConanProjectSettings conanProjectSettings = ConanProjectSettings.getInstance(project);
         Map<CMakeProfile, ConanProfile> profileMapping = conanProjectSettings.getProfileMapping();

--- a/src/main/java/conan/actions/CleanCacheAction.java
+++ b/src/main/java/conan/actions/CleanCacheAction.java
@@ -4,10 +4,6 @@ import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.ui.DialogWrapper;
-import com.intellij.openapi.ui.JBPopupMenu;
-import com.intellij.openapi.ui.popup.JBPopupFactory;
-import com.intellij.util.ui.ConfirmationDialog;
 import conan.ui.ConanConfirmDialog;
 
 /**
@@ -17,6 +13,8 @@ import conan.ui.ConanConfirmDialog;
  */
 public class CleanCacheAction extends AnAction implements DumbAware {
 
+    private static final String wipeCacheConfirmMessage = "This will remove the Conan local cache, Are you sure?";
+
     @Override
     public void actionPerformed(AnActionEvent anActionEvent) {
         Project project = getEventProject(anActionEvent);
@@ -24,9 +22,8 @@ public class CleanCacheAction extends AnAction implements DumbAware {
             if (!ActionUtils.isConanInstalled(project)) {
                 return;
             }
-            String message = "This will remove the Conan local cache, Are you sure?";
-            boolean result = new ConanConfirmDialog("Removing Conan Cache", message).showAndGet();
-            if(result) {
+            boolean result = new ConanConfirmDialog("Removing Conan Cache", wipeCacheConfirmMessage).showAndGet();
+            if (result) {
                 // user pressed ok
                 new conan.commands.CleanCache(project).run();
             }

--- a/src/main/java/conan/actions/CleanCacheAction.java
+++ b/src/main/java/conan/actions/CleanCacheAction.java
@@ -3,6 +3,12 @@ package conan.actions;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.DialogWrapper;
+import com.intellij.openapi.ui.JBPopupMenu;
+import com.intellij.openapi.ui.popup.JBPopupFactory;
+import com.intellij.util.ui.ConfirmationDialog;
+import conan.ui.ConanConfirmDialog;
 
 /**
  * Clean conan cache.
@@ -13,8 +19,17 @@ public class CleanCacheAction extends AnAction implements DumbAware {
 
     @Override
     public void actionPerformed(AnActionEvent anActionEvent) {
-        if (getEventProject(anActionEvent) != null) {
-            new conan.commands.CleanCache(anActionEvent.getProject()).run();
+        Project project = getEventProject(anActionEvent);
+        if (project != null) {
+            if (!ActionUtils.isInstalled(project)) {
+                return;
+            }
+            String message = "This will remove the Conan local cache, Are you sure?";
+            boolean result = new ConanConfirmDialog("Removing Conan Cache", message).showAndGet();
+            if(result) {
+                // user pressed ok
+                new conan.commands.CleanCache(project).run();
+            }
         }
     }
 }

--- a/src/main/java/conan/actions/CleanCacheAction.java
+++ b/src/main/java/conan/actions/CleanCacheAction.java
@@ -21,7 +21,7 @@ public class CleanCacheAction extends AnAction implements DumbAware {
     public void actionPerformed(AnActionEvent anActionEvent) {
         Project project = getEventProject(anActionEvent);
         if (project != null) {
-            if (!ActionUtils.isInstalled(project)) {
+            if (!ActionUtils.isConanInstalled(project)) {
                 return;
             }
             String message = "This will remove the Conan local cache, Are you sure?";

--- a/src/main/java/conan/actions/MatchProfilesAction.java
+++ b/src/main/java/conan/actions/MatchProfilesAction.java
@@ -19,7 +19,7 @@ public class MatchProfilesAction extends AnAction implements DumbAware {
         if (project == null) {
             return;
         }
-        if(!ActionUtils.isInstalled(project)){
+        if(!ActionUtils.isConanInstalled(project)){
             return;
         }
         ProfileMatcher.showDialog(project, anActionEvent.getInputEvent().getComponent());

--- a/src/main/java/conan/actions/MatchProfilesAction.java
+++ b/src/main/java/conan/actions/MatchProfilesAction.java
@@ -19,7 +19,7 @@ public class MatchProfilesAction extends AnAction implements DumbAware {
         if (project == null) {
             return;
         }
-        if(!ActionUtils.isConanInstalled(project)){
+        if (!ActionUtils.isConanInstalled(project)){
             return;
         }
         ProfileMatcher.showDialog(project, anActionEvent.getInputEvent().getComponent());

--- a/src/main/java/conan/actions/MatchProfilesAction.java
+++ b/src/main/java/conan/actions/MatchProfilesAction.java
@@ -19,6 +19,9 @@ public class MatchProfilesAction extends AnAction implements DumbAware {
         if (project == null) {
             return;
         }
+        if(!ActionUtils.isInstalled(project)){
+            return;
+        }
         ProfileMatcher.showDialog(project, anActionEvent.getInputEvent().getComponent());
     }
 }

--- a/src/main/java/conan/actions/OpenConfigAction.java
+++ b/src/main/java/conan/actions/OpenConfigAction.java
@@ -20,6 +20,7 @@ public class OpenConfigAction extends AnAction implements DumbAware {
         if (project == null) {
             return;
         }
+
         ShowSettingsUtil.getInstance().showSettingsDialog(project, ConanConfig.CONFIG_NAME);
     }
 }

--- a/src/main/java/conan/commands/CleanCache.java
+++ b/src/main/java/conan/commands/CleanCache.java
@@ -14,7 +14,7 @@ public class CleanCache extends AsyncConanCommand {
         super(project, "remove", "*", "-f");
     }
 
-    public CleanCache(ProcessListener processListener) {
-        super(null, null, processListener,"remove", "*", "-f");
+    public CleanCache(Project project, ProcessListener processListener) {
+        super(project, null, processListener,"remove", "*", "-f");
     }
 }

--- a/src/main/java/conan/commands/ConanCommandBase.java
+++ b/src/main/java/conan/commands/ConanCommandBase.java
@@ -2,11 +2,15 @@ package conan.commands;
 
 import com.google.common.collect.Lists;
 import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.notification.NotificationType;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.text.StringUtil;
+import conan.persistency.settings.ConanProjectSettings;
 import conan.utils.Utils;
-import org.jetbrains.annotations.Nullable;
 
 import static conan.utils.Utils.CONAN_HOME_ENV;
+import static conan.utils.Utils.log;
 
 /**
  * Base class for all Conan commands.
@@ -15,15 +19,24 @@ import static conan.utils.Utils.CONAN_HOME_ENV;
  */
 abstract class ConanCommandBase implements Runnable {
 
+    private static final Logger logger = Logger.getInstance(ConanCommandBase.class);
+
     GeneralCommandLine args;
 
-    ConanCommandBase(@Nullable Project project, String... args) {
-        this.args = new GeneralCommandLine(Lists.asList("conan", args));
-
-        if (project != null) {
-            this.args.setWorkDirectory(project.getBaseDir().getCanonicalPath());
+    ConanCommandBase(Project project, String... args) {
+        ConanProjectSettings conanProjectSettings = ConanProjectSettings.getInstance(project);
+        String envExePath = System.getenv("CONAN_EXE_PATH");
+        if(envExePath != null){
+            log(logger, "Conan at: ", envExePath, NotificationType.INFORMATION);
+            this.args = new GeneralCommandLine(Lists.asList(envExePath, args));
         }
-
+        else {
+            String configPath = conanProjectSettings.getConanPath();
+            String conanExe = StringUtil.isEmpty(configPath) ? "conan" : configPath;
+            log(logger, "Conan at: ", conanExe, NotificationType.INFORMATION);
+            this.args = new GeneralCommandLine(Lists.asList(conanExe, args));
+        }
+        this.args.setWorkDirectory(project.getBaseDir().getCanonicalPath());
         String conanHome = Utils.getConanHomeEnv();
         if (conanHome != null) {
             this.args.withEnvironment(CONAN_HOME_ENV, conanHome);

--- a/src/main/java/conan/commands/Config.java
+++ b/src/main/java/conan/commands/Config.java
@@ -1,6 +1,7 @@
 package conan.commands;
 
 import com.intellij.execution.process.ProcessAdapter;
+import com.intellij.openapi.project.Project;
 
 /**
  * Used to initialize conan.
@@ -9,7 +10,7 @@ import com.intellij.execution.process.ProcessAdapter;
  * Created by Yahav Itzhak on Feb 2018.
  */
 public class Config extends SyncConanCommand {
-    public Config() {
-        super(null, new ProcessAdapter(){}, "config");
+    public Config(Project p) {
+        super(p, new ProcessAdapter(){}, "config");
     }
 }

--- a/src/main/java/conan/commands/ConfigInstall.java
+++ b/src/main/java/conan/commands/ConfigInstall.java
@@ -1,6 +1,7 @@
 package conan.commands;
 
 import com.intellij.execution.process.ProcessListener;
+import com.intellij.openapi.project.Project;
 
 /**
  * Download and install Conan configuration.
@@ -10,7 +11,7 @@ import com.intellij.execution.process.ProcessListener;
  */
 public class ConfigInstall extends AsyncConanCommand {
 
-    public ConfigInstall(ProcessListener processListener, String url) {
-        super(null, null, processListener, "config", "install", url);
+    public ConfigInstall(Project project, ProcessListener processListener, String url) {
+        super(project, null, processListener, "config", "install", url);
     }
 }

--- a/src/main/java/conan/commands/NewProfile.java
+++ b/src/main/java/conan/commands/NewProfile.java
@@ -1,6 +1,7 @@
 package conan.commands;
 
 import com.intellij.execution.process.ProcessListener;
+import com.intellij.openapi.project.Project;
 import conan.profiles.ConanProfile;
 
 /**
@@ -11,7 +12,7 @@ import conan.profiles.ConanProfile;
  */
 public class NewProfile extends AsyncConanCommand {
 
-    public NewProfile(ProcessListener processListener, ConanProfile conanProfile) {
-        super(null, null, processListener, "profile", "new", conanProfile.getName());
+    public NewProfile(Project project, ProcessListener processListener, ConanProfile conanProfile) {
+        super(project, null, processListener, "profile", "new", conanProfile.getName());
     }
 }

--- a/src/main/java/conan/commands/Search.java
+++ b/src/main/java/conan/commands/Search.java
@@ -1,6 +1,7 @@
 package conan.commands;
 
 import com.intellij.execution.process.ProcessListener;
+import com.intellij.openapi.project.Project;
 
 /**
  * Search Conan packages. Send the results to the input process listener.
@@ -10,7 +11,7 @@ import com.intellij.execution.process.ProcessListener;
  */
 public class Search extends AsyncConanCommand {
 
-    public Search(ProcessListener processListener) {
-        super(null, null, processListener, "search", "--raw");
+    public Search(Project project, ProcessListener processListener) {
+        super(project, null, processListener, "search", "--raw");
     }
 }

--- a/src/main/java/conan/commands/SyncConanCommand.java
+++ b/src/main/java/conan/commands/SyncConanCommand.java
@@ -17,7 +17,7 @@ public abstract class SyncConanCommand extends ConanCommandBase {
 
     private SyncConanTask conanTask;
 
-    protected SyncConanCommand(@Nullable Project project, @Nullable ProcessListener processListener, String... args) {
+    protected SyncConanCommand(Project project, @Nullable ProcessListener processListener, String... args) {
         super(project, args);
         conanTask = new SyncConanTask(project, processListener, super.args);
     }

--- a/src/main/java/conan/commands/listProfiles/GetConanProfiles.java
+++ b/src/main/java/conan/commands/listProfiles/GetConanProfiles.java
@@ -1,5 +1,6 @@
 package conan.commands.listProfiles;
 
+import com.intellij.openapi.project.Project;
 import conan.commands.SyncConanCommand;
 import conan.profiles.ConanProfile;
 
@@ -13,7 +14,7 @@ import java.util.List;
  */
 public class GetConanProfiles extends SyncConanCommand {
 
-    public GetConanProfiles(List<ConanProfile> profiles) {
-        super(null, new GetConanProfilesProcessListener(profiles), "profile", "list");
+    public GetConanProfiles(List<ConanProfile> profiles, Project project) {
+        super(project, new GetConanProfilesProcessListener(profiles), "profile", "list");
     }
 }

--- a/src/main/java/conan/persistency/Keys.java
+++ b/src/main/java/conan/persistency/Keys.java
@@ -9,4 +9,5 @@ import com.intellij.ide.util.PropertiesComponent;
  */
 public class Keys {
     public static final String CONFIG_INSTALL_URL = "conan.config.install.url";
+    public static final String CONFIG_CONAN_EXE_PATH = "conan.path";
 }

--- a/src/main/java/conan/persistency/settings/ConanProjectSettings.java
+++ b/src/main/java/conan/persistency/settings/ConanProjectSettings.java
@@ -20,6 +20,7 @@ public class ConanProjectSettings implements PersistentStateComponent<ConanProje
 
     private Map<CMakeProfile, ConanProfile> profileMapping = Maps.newHashMap();
     private String installArgs;
+    private String conanPath;
 
     public static ConanProjectSettings getInstance(Project project) {
         return ServiceManager.getService(project, ConanProjectSettings.class);
@@ -47,7 +48,15 @@ public class ConanProjectSettings implements PersistentStateComponent<ConanProje
         return installArgs;
     }
 
+    public String getConanPath() {
+        return conanPath;
+    }
+
     public void setInstallArgs(String installArgs) {
         this.installArgs = installArgs;
+    }
+
+    public void setConanPath(String conanPath) {
+        this.conanPath = conanPath;
     }
 }

--- a/src/main/java/conan/profiles/ProfileUtils.java
+++ b/src/main/java/conan/profiles/ProfileUtils.java
@@ -31,11 +31,11 @@ public class ProfileUtils {
      * Extract Conan profiles.
      * @return list of Conan profiles.
      */
-    public static List<ConanProfile> getConanProfiles() {
+    public static List<ConanProfile> getConanProfiles(Project project) {
         List<ConanProfile> profiles = Lists.newArrayList();
         // Prevents "Remotes registry file missing" message
-        new Config().run();
-        new GetConanProfiles(profiles).run();
+        new Config(project).run();
+        new GetConanProfiles(profiles, project).run();
         return profiles;
     }
 

--- a/src/main/java/conan/ui/ConanConfirmDialog.java
+++ b/src/main/java/conan/ui/ConanConfirmDialog.java
@@ -1,0 +1,30 @@
+package conan.ui;
+
+import com.intellij.openapi.ui.DialogWrapper;
+import com.intellij.ui.components.JBLabel;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.awt.*;
+
+public class ConanConfirmDialog extends DialogWrapper {
+
+    private String body;
+
+    public ConanConfirmDialog(String title, String body) {
+        super(false); // use current window as parent
+        setTitle(title);
+        this.body = body;
+        init();
+    }
+
+    @Nullable
+    @Override
+    protected JComponent createCenterPanel() {
+        JPanel dialogPanel = new JPanel(new BorderLayout());
+        JBLabel label = new JBLabel(body);
+        label.setPreferredSize(new Dimension(100, 100));
+        dialogPanel.add(label, BorderLayout.CENTER);
+        return dialogPanel;
+    }
+}

--- a/src/main/java/conan/ui/ConanToolWindow.java
+++ b/src/main/java/conan/ui/ConanToolWindow.java
@@ -74,7 +74,7 @@ public class ConanToolWindow implements Disposable {
     private void createConanProfilesTabs(@NotNull Project project, ContentFactory contentFactory) {
         ConanProjectSettings conanProjectSettings = ConanProjectSettings.getInstance(project);
         Map<CMakeProfile, ConanProfile> profileMatching = conanProjectSettings.getProfileMapping();
-        for (ConanProfile conanProfile : ProfileUtils.getConanProfiles()) {
+        for (ConanProfile conanProfile : ProfileUtils.getConanProfiles(project)) {
             if (!profileMatching.containsValue(conanProfile)) {
                 continue;
             }

--- a/src/main/java/conan/ui/configuration/ConanConfig.form
+++ b/src/main/java/conan/ui/configuration/ConanConfig.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="conan.ui.configuration.ConanConfig">
-  <grid id="27dc6" binding="rootPanel" layout-manager="GridLayoutManager" row-count="4" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="rootPanel" layout-manager="GridLayoutManager" row-count="5" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -16,11 +16,6 @@
           <text value="Config install URL"/>
         </properties>
       </component>
-      <vspacer id="a0f40">
-        <constraints>
-          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
-        </constraints>
-      </vspacer>
       <component id="3a1a3" class="javax.swing.JTextField" binding="configInstallUrl">
         <constraints>
           <grid row="0" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
@@ -39,7 +34,7 @@
       </component>
       <component id="251ff" class="javax.swing.JLabel" binding="configInstallRes">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="4" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="0" row-span="1" col-span="4" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value=""/>
@@ -47,7 +42,7 @@
       </component>
       <component id="8f103" class="com.intellij.ui.components.JBTextField" binding="installArgs">
         <constraints>
-          <grid row="1" column="1" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="2" column="1" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
@@ -55,12 +50,31 @@
       </component>
       <component id="48cbe" class="javax.swing.JLabel" binding="installArgsLabel">
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <requestFocusEnabled value="true"/>
           <text value="Install args"/>
         </properties>
+      </component>
+      <component id="23a2c" class="javax.swing.JLabel" binding="conanPathLabel">
+        <constraints>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Conan executable"/>
+        </properties>
+      </component>
+      <vspacer id="a11c">
+        <constraints>
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </vspacer>
+      <component id="76160" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="conanPath">
+        <constraints>
+          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
       </component>
     </children>
   </grid>

--- a/src/main/java/conan/ui/configuration/ConanConfig.java
+++ b/src/main/java/conan/ui/configuration/ConanConfig.java
@@ -3,8 +3,15 @@ package conan.ui.configuration;
 import com.intellij.execution.Output;
 import com.intellij.execution.OutputListener;
 import com.intellij.execution.process.ProcessEvent;
+import com.intellij.openapi.fileChooser.FileChooser;
+import com.intellij.openapi.fileChooser.FileChooserDescriptor;
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
 import com.intellij.openapi.options.Configurable;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.TextFieldWithBrowseButton;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.JBColor;
 import com.intellij.ui.components.JBTextField;
 import com.intellij.uiDesigner.core.GridConstraints;
@@ -22,6 +29,7 @@ import org.jetbrains.annotations.Nullable;
 import javax.swing.*;
 import java.awt.*;
 
+import static conan.persistency.Keys.CONFIG_CONAN_EXE_PATH;
 import static conan.persistency.Keys.CONFIG_INSTALL_URL;
 
 /**
@@ -41,11 +49,16 @@ public class ConanConfig implements Configurable, Configurable.NoScroll {
     private JBTextField installArgs;
     private JLabel installArgsLabel;
 
+    private JLabel conanPathLabel;
+    private TextFieldWithBrowseButton conanPath;
+
+
     public ConanConfig(@NotNull Project project) {
         this.project = project;
         if (project.isDefault()) { // No project
             installArgs.setVisible(false);
             installArgsLabel.setVisible(false);
+            conanPathLabel.setVisible(false);
         }
     }
 
@@ -71,6 +84,21 @@ public class ConanConfig implements Configurable, Configurable.NoScroll {
             runConfigInstall(url);
         });
         installArgs.getEmptyText().setText("Arguments other than '--if', '--pr' and '--update'");
+        String envExePath = System.getenv("CONAN_EXE_PATH");
+        if(envExePath != null) {
+            conanPath.setText(envExePath);
+        }
+        conanPath.setToolTipText("Path to the Conan executable, by default it will search in the path");
+
+        conanPath.addActionListener(actionEvent -> {
+            final FileChooserDescriptor d = FileChooserDescriptorFactory.createSingleFileDescriptor();
+            VirtualFile initialFile = StringUtil.isNotEmpty(conanPath.getText()) ? LocalFileSystem.getInstance().findFileByPath(conanPath.getText()) : null;
+            VirtualFile file = FileChooser.chooseFile(d, project, initialFile);
+            if (file != null) {
+                conanPath.setText(file.getCanonicalPath());
+            }
+        });
+
         return rootPanel;
     }
 
@@ -92,7 +120,7 @@ public class ConanConfig implements Configurable, Configurable.NoScroll {
                 }
             }
         };
-        new ConfigInstall(processListener, url).run();
+        new ConfigInstall(this.project, processListener, url).run();
     }
 
     private void setConfigInstallRes(String results, boolean isSuccess) {
@@ -110,14 +138,17 @@ public class ConanConfig implements Configurable, Configurable.NoScroll {
         configInstallUrl.setText(PersistencyUtils.getValue(CONFIG_INSTALL_URL));
         if (!project.isDefault()) {
             installArgs.setText(ConanProjectSettings.getInstance(project).getInstallArgs());
+            conanPath.setText(ConanProjectSettings.getInstance(project).getConanPath());
         }
     }
 
     @Override
     public void apply() {
         PersistencyUtils.setValue(CONFIG_INSTALL_URL, configInstallUrl.getText());
+        PersistencyUtils.setValue(CONFIG_CONAN_EXE_PATH, conanPath.getText());
         if (!project.isDefault()) {
             ConanProjectSettings.getInstance(project).setInstallArgs(installArgs.getText());
+            ConanProjectSettings.getInstance(project).setConanPath(conanPath.getText());
         }
     }
 

--- a/src/main/java/conan/ui/configuration/ConanConfig.java
+++ b/src/main/java/conan/ui/configuration/ConanConfig.java
@@ -52,7 +52,6 @@ public class ConanConfig implements Configurable, Configurable.NoScroll {
     private JLabel conanPathLabel;
     private TextFieldWithBrowseButton conanPath;
 
-
     public ConanConfig(@NotNull Project project) {
         this.project = project;
         if (project.isDefault()) { // No project
@@ -85,7 +84,7 @@ public class ConanConfig implements Configurable, Configurable.NoScroll {
         });
         installArgs.getEmptyText().setText("Arguments other than '--if', '--pr' and '--update'");
         String envExePath = System.getenv("CONAN_EXE_PATH");
-        if(envExePath != null) {
+        if( envExePath != null) {
             conanPath.setText(envExePath);
         }
         conanPath.setToolTipText("Path to the Conan executable, by default it will search in the path");

--- a/src/main/java/conan/ui/profileMatching/ProfileMatcher.java
+++ b/src/main/java/conan/ui/profileMatching/ProfileMatcher.java
@@ -56,6 +56,8 @@ public class ProfileMatcher extends JDialog {
 
         // call onCancel() on ESCAPE
         contentPane.registerKeyboardAction(e -> onCancel(), KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT);
+
+        populateProfileMatchingTable(project);
     }
 
     /**
@@ -85,7 +87,6 @@ public class ProfileMatcher extends JDialog {
     private void createUIComponents() {
         createProfileMatchingTable();
         createProfilesMap();
-        populateProfileMatchingTable();
     }
 
     /**
@@ -116,9 +117,9 @@ public class ProfileMatcher extends JDialog {
     /**
      * Populate the profile matching table.
      */
-    private void populateProfileMatchingTable() {
+    private void populateProfileMatchingTable(Project project) {
         profileMatchingTable.setModel(new ProfileMatchingTableModel(profileMapping));
-        profileMatchingTable.setDefaultEditor(ConanProfile.class, new ProfileMatchingCellEditor(profileMapping));
+        profileMatchingTable.setDefaultEditor(ConanProfile.class, new ProfileMatchingCellEditor(profileMapping, project));
     }
 
     /**

--- a/src/main/java/conan/ui/profileMatching/ProfileMatchingCellEditor.java
+++ b/src/main/java/conan/ui/profileMatching/ProfileMatchingCellEditor.java
@@ -1,5 +1,6 @@
 package conan.ui.profileMatching;
 
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.ComboBox;
 import conan.profiles.CMakeProfile;
 import conan.profiles.ConanProfile;
@@ -25,9 +26,9 @@ class ProfileMatchingCellEditor extends AbstractCellEditor implements TableCellE
     private Map<CMakeProfile, ConanProfile> profileMapping;
     private List<ConanProfile> conanProfiles;
 
-    ProfileMatchingCellEditor(Map<CMakeProfile, ConanProfile> profileMapping) {
+    ProfileMatchingCellEditor(Map<CMakeProfile, ConanProfile> profileMapping, Project project) {
         this.profileMapping = profileMapping;
-        this.conanProfiles = ProfileUtils.getConanProfiles();
+        this.conanProfiles = ProfileUtils.getConanProfiles(project);
     }
 
     @Override

--- a/src/test/java/conan/commands/ConanCommandTestBase.java
+++ b/src/test/java/conan/commands/ConanCommandTestBase.java
@@ -1,5 +1,7 @@
 package conan.commands;
 
+import com.intellij.openapi.project.Project;
+import conan.testUtils.OpenSSLProjectImpl;
 import conan.testUtils.Utils;
 import org.apache.commons.io.FileUtils;
 import org.testng.annotations.AfterClass;
@@ -13,11 +15,13 @@ import static conan.utils.Utils.CONAN_HOME_ENV;
 public abstract class ConanCommandTestBase {
 
     private File conanHomeDir;
+    Project project;
 
     @BeforeClass(alwaysRun = true)
     public void setConanHome() {
         conanHomeDir = Utils.createTempDir();
         System.setProperty(CONAN_HOME_ENV, conanHomeDir.getAbsolutePath());
+        project = new OpenSSLProjectImpl();
     }
 
     @AfterClass(alwaysRun = true)

--- a/src/test/java/conan/commands/ConfigInstallTest.java
+++ b/src/test/java/conan/commands/ConfigInstallTest.java
@@ -9,7 +9,6 @@ import static conan.testUtils.Utils.*;
 @Test
 public class ConfigInstallTest extends ConanCommandTestBase {
 
-
     @Test
     public void testConfigInstall() {
         verifyProfiles(Sets.newHashSet(), project );

--- a/src/test/java/conan/commands/ConfigInstallTest.java
+++ b/src/test/java/conan/commands/ConfigInstallTest.java
@@ -9,10 +9,11 @@ import static conan.testUtils.Utils.*;
 @Test
 public class ConfigInstallTest extends ConanCommandTestBase {
 
+
     @Test
     public void testConfigInstall() {
-        verifyProfiles(Sets.newHashSet());
+        verifyProfiles(Sets.newHashSet(), project );
         configInstall();
-        verifyProfiles(BINCRAFTERS_PROFILES);
+        verifyProfiles(BINCRAFTERS_PROFILES, project);
     }
 }

--- a/src/test/java/conan/commands/ListProfilesTest.java
+++ b/src/test/java/conan/commands/ListProfilesTest.java
@@ -20,8 +20,8 @@ public class ListProfilesTest extends ConanCommandTestBase {
 
     @Test
     public void testListProfiles() {
-        //verifyProfiles(Sets.newHashSet());
+        verifyProfiles(Sets.newHashSet(), project);
         createProfiles(TEST_PROFILES);
-        //verifyProfiles(TEST_PROFILES);
+        verifyProfiles(TEST_PROFILES, project);
     }
 }

--- a/src/test/java/conan/commands/ListProfilesTest.java
+++ b/src/test/java/conan/commands/ListProfilesTest.java
@@ -20,8 +20,8 @@ public class ListProfilesTest extends ConanCommandTestBase {
 
     @Test
     public void testListProfiles() {
-        verifyProfiles(Sets.newHashSet());
+        //verifyProfiles(Sets.newHashSet());
         createProfiles(TEST_PROFILES);
-        verifyProfiles(TEST_PROFILES);
+        //verifyProfiles(TEST_PROFILES);
     }
 }

--- a/src/test/java/conan/testUtils/Consts.java
+++ b/src/test/java/conan/testUtils/Consts.java
@@ -11,9 +11,7 @@ public class Consts {
     static final Set<String> CONAN_INSTALL_FILES = Sets.newHashSet("conanbuildinfo.cmake", "conanbuildinfo.txt", "conaninfo.txt");
     public static final Set<String> OPENSSL_PACKAGES = Sets.newHashSet("OpenSSL", "zlib");
     static final String BINCRAFTERS_URL = "https://github.com/bincrafters/conan-config.git";
-    public static final Set<ConanProfile> BINCRAFTERS_PROFILES = Sets.newHashSet("freebsd-clang34-amd64", "linux-clang39-amd64",
-            "linux-clang40-amd64", "linux-gcc41-amd64", "linux-gcc48-amd64", "linux-gcc49-amd64", "linux-gcc54-amd64",
-            "linux-gcc63-amd64", "orangepi", "windows-msvc12-amd64", "windows-msvc14-amd64", "windows-msvc15-amd64")
+    public static final Set<ConanProfile> BINCRAFTERS_PROFILES = Sets.newHashSet("linux-gcc49-amd64", "linux-clang39-amd64", "windows-msvc12-amd64", "android-clang7-i386", "android-clang8-amd64", "linux-gcc54-amd64", "orangepi", "freebsd-clang34-amd64", "linux-gcc48-amd64", "linux-gcc63-amd64", "linux-clang40-amd64", "android-clang7-amd64", "android-clang7-armv7", "android-clang7-armv8", "android-clang8-i386", "windows-msvc14-amd64", "windows-msvc15-amd64", "android-clang8-armv7", "android-clang8-armv8", "linux-gcc41-amd64")
             .parallelStream()
             .map(ConanProfile::new)
             .collect(Collectors.toSet());

--- a/src/test/java/conan/testUtils/Utils.java
+++ b/src/test/java/conan/testUtils/Utils.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Sets;
 import com.google.common.io.Files;
 import com.intellij.execution.process.ProcessAdapter;
 import com.intellij.openapi.progress.DumbProgressIndicator;
+import com.intellij.openapi.project.Project;
 import conan.commands.*;
 import conan.commands.listProfiles.GetConanProfiles;
 import conan.commands.task.AsyncConanTask;
@@ -45,30 +46,30 @@ public class Utils {
     }
 
     public static void verifyPackages(Set<String> expectedPackages) {
-        AsyncConanCommand search = new Search(new ConanPackagesVerifier(expectedPackages));
+        AsyncConanCommand search = new Search(new OpenSSLProjectImpl(), new ConanPackagesVerifier(expectedPackages));
         Utils.runConanCommand(search);
     }
 
     public static void cleanCache() {
-        AsyncConanCommand cleanCache = new CleanCache(new ProcessAdapter(){});
+        AsyncConanCommand cleanCache = new CleanCache(new OpenSSLProjectImpl(), new ProcessAdapter(){});
         Utils.runConanCommand(cleanCache);
     }
 
-    public static void verifyProfiles(Set<ConanProfile> expectedProfiles) {
+    public static void verifyProfiles(Set<ConanProfile> expectedProfiles, Project project) {
         List<ConanProfile> conanProfiles = Lists.newArrayList();
-        Utils.runConanCommand(new Config()); // Prevents "Remotes registry file missing" message
-        Utils.runConanCommand(new GetConanProfiles(conanProfiles));
+        Utils.runConanCommand(new Config(project)); // Prevents "Remotes registry file missing" message
+        Utils.runConanCommand(new GetConanProfiles(conanProfiles, project));
         Assert.assertEquals(Sets.newHashSet(conanProfiles), expectedProfiles);
     }
 
     public static void configInstall() {
-        AsyncConanCommand configInstall = new ConfigInstall(new ProcessAdapter(){}, BINCRAFTERS_URL);
+        AsyncConanCommand configInstall = new ConfigInstall(new OpenSSLProjectImpl(), new ProcessAdapter(){}, BINCRAFTERS_URL);
         Utils.runConanCommand(configInstall);
     }
 
     public static void createProfiles(Set<ConanProfile> newProfiles) {
         newProfiles.forEach(newProfile -> {
-            AsyncConanCommand newProfileCommand = new NewProfile(new ProcessAdapter(){}, newProfile);
+            AsyncConanCommand newProfileCommand = new NewProfile(new OpenSSLProjectImpl(), new ProcessAdapter(){}, newProfile);
             Utils.runConanCommand(newProfileCommand);
         });
     }


### PR DESCRIPTION
- Allowed to configure the Conan executable path.
- Fixed exceptions raised and other unexpected behaviors when no conan executable is found.
- Added confirmation dialog before wiping the local cache.

Close #25 
