### PR TITLE
Improve CI. Deploy new releases from tags using Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 *.iml
 .gradle
 build/
+.classpath
+.project
+.settings/
+bin/

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,8 @@ jobs:
     - stage: checks
       name: "Check version"
       addons:
-      before_install:
-        - echo "Skip before_install"
-      install:
-        - echo "Skip install"
+      before_install: true
+      install: true
       script:
         # Check that the version value matches the tag one (right at the very beginning)
         - version=$(sed -e '/^pluginVersion = */!d; s///;q' gradle.properties) || travis_terminate 1;

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,8 @@ jobs:
         - ./gradlew clean build
         - "curl -i --header \"Authorization: Bearer $DEPLOY_TOKEN\" -F pluginId=$PLUGIN_ID -F file=@$(pwd)/build/distributions/Conan-$version.zip -F channel=$DEPLOY_CHANNEL https://plugins.jetbrains.com/plugin/uploadPlugin"
         - status="$?"
-        - echo "Exit code is $status"
-        - exit "$status"
+        - echo "curl returned $status"
+        # - exit "$status"  # TODO: Even if curl succeeded, I get value "1".
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,49 @@
-os:
-  - osx
-  - linux
+sudo: false
 language: java
+dist: xenial
+
+stages:
+  - name: checks
+    if: tag IS present
+  - test
+  - name: deploy
+    if: tag IS present
+
+jobs:
+  fast_finish: true
+  include:
+
+    - stage: checks
+      name: "Check version"
+      addons:
+      before_install:
+        - echo "Skip before_install"
+      install:
+        - echo "Skip install"
+      script:
+        # Check that the version value matches the tag one (right at the very beginning)
+        - version=$(sed -e '/^pluginVersion = */!d; s///;q' gradle.properties) || travis_terminate 1;
+        - echo "Value found in gradle.properties=$version, tag is $TRAVIS_TAG"
+        - if [ "$version" != "$TRAVIS_TAG" ]; then echo "Version mismatch!"; travis_terminate 1; fi
+
+    - stage: test
+      name: "Linux"
+      os: linux
+      jdk: openjdk8
+    - name: "Macos"
+      os: osx
+
+    - stage: deploy
+      name: "Deploy to Jetbrains marketplace"
+      os: linux
+      jdk: openjdk8
+      script:
+        - version=$(sed -e '/^pluginVersion = */!d; s///;q' gradle.properties) || travis_terminate 1;
+        - if [ "$version" != "$TRAVIS_TAG" ]; then echo "Version mismatch!"; travis_terminate 1; fi
+        # Build and upload
+        - ./gradlew clean build
+        - "curl -i --header \"Authorization: Bearer $DEPLOY_TOKEN\" -F pluginId=11956 -F file=@$(pwd)/build/distributions/Conan-$version.zip -F channel=ci https://plugins.jetbrains.com/plugin/uploadPlugin"
+
 addons:
   apt:
     sources:
@@ -9,10 +51,19 @@ addons:
     packages:
       - gcc-7
       - g++-7
+
+before_install:
+  - if [ $TRAVIS_OS_NAME == osx ]; then
+      brew update;
+      brew install openssl readline;
+      brew outdated pyenv || brew upgrade pyenv;
+    fi
+  - pyenv install 3.6.3
+  - pyenv global 3.6.3
+  - python --version
+
 install:
+  - pip install conan
   - if [ $TRAVIS_OS_NAME = linux ]; then
       sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7;
-      sudo pip install conan;
-    else
-      brew install conan;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,12 +37,18 @@ jobs:
       name: "Deploy to Jetbrains marketplace"
       os: linux
       jdk: openjdk8
+      env:
+        - DEPLOY_CHANNEL=stable
+        - PLUGIN_ID=11956
       script:
         - version=$(sed -e '/^pluginVersion = */!d; s///;q' gradle.properties) || travis_terminate 1;
         - if [ "$version" != "$TRAVIS_TAG" ]; then echo "Version mismatch!"; travis_terminate 1; fi
         # Build and upload
         - ./gradlew clean build
-        - "curl -i --header \"Authorization: Bearer $DEPLOY_TOKEN\" -F pluginId=11956 -F file=@$(pwd)/build/distributions/Conan-$version.zip -F channel=ci https://plugins.jetbrains.com/plugin/uploadPlugin"
+        - "curl -i --header \"Authorization: Bearer $DEPLOY_TOKEN\" -F pluginId=$PLUGIN_ID -F file=@$(pwd)/build/distributions/Conan-$version.zip -F channel=$DEPLOY_CHANNEL https://plugins.jetbrains.com/plugin/uploadPlugin"
+        - status="$?"
+        - echo "Exit code is $status"
+        - exit "$status"
 
 addons:
   apt:


### PR DESCRIPTION
This PR modifies the CI for Travis, it implements three stages:
1. Checks (only tags): check that the tag matches the plugin version
2. Tests: run testing for Macos and Linux
3. Deploy (only tags): build the plugin and deploy it to Jetbrains marketplace

![image](https://user-images.githubusercontent.com/1406456/63087694-16f73000-bf53-11e9-9883-39ec6ef2b712.png)


The deploy stage needs an environment variable `DEPLOY_TOKEN` that should contain a valid token (https://plugins.jetbrains.com/docs/marketplace/plugin-upload.html).
