### PR TITLE
Remove macos jobs, one job per CLion version [skip changelog]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,5 +73,5 @@ addons:
 install:
   - python3 --version
   - python3 -m pip || curl -s https://bootstrap.pypa.io/get-pip.py | python3 - --user
-  - python3 -m pip install conan
+  - python3 -m pip install --user conan
   - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7;

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
+      - deadsnakes
     packages:
       - gcc-7
       - g++-7

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,6 @@ addons:
       - python3.6
 
 install:
-  - python --version
-  - pip install conan
+  - python3 --version
+  - pip3 install conan
   - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7;

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,5 +72,6 @@ addons:
 
 install:
   - python3 --version
+  - python3 -m pip || wget https://bootstrap.pypa.io/get-pip.py | python3
   - python3 -m pip install conan
   - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7;

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,17 +33,17 @@ jobs:
       os: linux
       jdk: openjdk8
       script:
-        - ./gradlew test -PclionVersion=2018.3.4
+        - ./gradlew test -PclionVersion=2018.3 --stacktrace
     - name: "CLion 2019.1"
       os: linux
       jdk: openjdk8
       script:
-        - ./gradlew test -PclionVersion=2019.1.4
+        - ./gradlew test -PclionVersion=2019.1 --stacktrace
     - name: "CLion 2019.2"
       os: linux
       jdk: openjdk8
       script:
-        - ./gradlew test -PclionVersion=2019.2
+        - ./gradlew test -PclionVersion=2019.2 --stacktrace
 
     - stage: deploy
       name: "Deploy to Jetbrains marketplace"

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,6 @@ addons:
 
 install:
   - python3 --version
-  - python3 -m pip || wget https://bootstrap.pypa.io/get-pip.py | python3 -
+  - python3 -m pip || curl -s https://bootstrap.pypa.io/get-pip.py | python3 -
   - python3 -m pip install conan
   - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7;

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,11 +66,9 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - deadsnakes
     packages:
       - gcc-7
       - g++-7
-      - python3.6
 
 install:
   - python3 --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,6 @@ addons:
 
 install:
   - python3 --version
-  - python3 -m pip || curl -s https://bootstrap.pypa.io/get-pip.py | python3 -
+  - python3 -m pip || curl -s https://bootstrap.pypa.io/get-pip.py | python3 - --user
   - python3 -m pip install conan
   - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7;

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,16 +29,21 @@ jobs:
         - if [ "$version" != "$TRAVIS_TAG" ]; then echo "Version mismatch!"; travis_terminate 1; fi
 
     - stage: test
-      name: "Linux"
+      name: "CLion 2018.3"
       os: linux
       jdk: openjdk8
-      script: &test_all_versions
+      script:
         - ./gradlew test -PclionVersion=2018.3.4
+    - name: "CLion 2019.1"
+      os: linux
+      jdk: openjdk8
+      script:
         - ./gradlew test -PclionVersion=2019.1.4
+    - name: "CLion 2019.2"
+      os: linux
+      jdk: openjdk8
+      script:
         - ./gradlew test -PclionVersion=2019.2
-    - name: "Macos"
-      os: osx
-      script: *test_all_versions
 
     - stage: deploy
       name: "Deploy to Jetbrains marketplace"
@@ -64,19 +69,9 @@ addons:
     packages:
       - gcc-7
       - g++-7
-
-before_install:
-  - if [ $TRAVIS_OS_NAME == osx ]; then
-      brew update;
-      brew install openssl readline;
-      brew outdated pyenv || brew upgrade pyenv;
-    fi
-  - pyenv install 3.6.3
-  - pyenv global 3.6.3
-  - python --version
+      - python3.6
 
 install:
+  - python --version
   - pip install conan
-  - if [ $TRAVIS_OS_NAME = linux ]; then
-      sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7;
-    fi
+  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7;

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,5 +72,5 @@ addons:
 
 install:
   - python3 --version
-  - pip3 install conan
+  - python3 -m pip install conan
   - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7;

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,6 @@ addons:
 
 install:
   - python3 --version
-  - python3 -m pip || wget https://bootstrap.pypa.io/get-pip.py | python3
+  - python3 -m pip || wget https://bootstrap.pypa.io/get-pip.py | python3 -
   - python3 -m pip install conan
   - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7;


### PR DESCRIPTION
It is faster to have one job per CLion version as they run in parallel.

![image](https://user-images.githubusercontent.com/1406456/63543344-e438d300-c522-11e9-9c02-2706fa73dfeb.png)
