### PR TITLE
Refactor Conan command classes [skip changelog]

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 pluginVersion = 1.1.2
-clionVersion = 2019.1
+clionVersion = 2019.1.4

--- a/src/main/java/conan/actions/ActionUtils.java
+++ b/src/main/java/conan/actions/ActionUtils.java
@@ -48,7 +48,7 @@ class ActionUtils {
             matchProfilesAndInstall(project, component, update);
             return;
         }
-        cMakeProfiles.forEach(cMakeProfile -> new Install(project, cMakeProfile, conanProfile, update).run());
+        cMakeProfiles.forEach(cMakeProfile -> new Install(project, cMakeProfile, conanProfile, update).run(conanProfile));
     }
 
     /**
@@ -67,7 +67,7 @@ class ActionUtils {
         Map<CMakeProfile, ConanProfile> profileMapping = conanProjectSettings.getProfileMapping();
         profileMapping.forEach((cMakeProfile, conanProfile) -> {
             if (StringUtils.isNotBlank(conanProfile.getName())) {
-                new Install(project, cMakeProfile, conanProfile, update).run();
+                new Install(project, cMakeProfile, conanProfile, update).run(conanProfile);
             }
         });
     }

--- a/src/main/java/conan/actions/CleanCacheAction.java
+++ b/src/main/java/conan/actions/CleanCacheAction.java
@@ -24,7 +24,7 @@ public class CleanCacheAction extends AnAction implements DumbAware {
         boolean result = new ConanConfirmDialog("Removing Conan Cache", WIPE_CACHE_CONFIRM_MESSAGE).showAndGet();
         if (result) {
             // user pressed ok
-            new conan.commands.CleanCache(project).run();
+            new conan.commands.CleanCache(project).run(null);
         }
     }
 }

--- a/src/main/java/conan/commands/AsyncConanCommand.java
+++ b/src/main/java/conan/commands/AsyncConanCommand.java
@@ -15,25 +15,28 @@ import javax.swing.*;
  *
  * Created by Yahav Itzhak on Feb 2018.
  */
-public abstract class AsyncConanCommand extends ConanCommandBase {
+public class AsyncConanCommand implements Runnable {
 
     private AsyncConanTask conanTask;
 
-    AsyncConanCommand(@Nullable Project project, String... args) {
-        this(project, null, null, null, args);
+    AsyncConanCommand(ConanCommandBase conanCommand) {
+        this(conanCommand, null, null, null);
     }
 
-    AsyncConanCommand(@Nullable Project project, ConanProfile conanProfile, CMakeRunner.Listener cmakeListener, String... args) {
-        this(project, conanProfile, cmakeListener, null, args);
+    AsyncConanCommand(ConanCommandBase conanCommand, ConanProfile conanProfile) {
+        this(conanCommand, conanProfile, null, null);
     }
 
-    AsyncConanCommand(@Nullable Project project, ConanProfile conanProfile, ProcessListener processListener, String... args) {
-        this(project, conanProfile, null, processListener, args);
+    AsyncConanCommand(ConanCommandBase conanCommand, ConanProfile conanProfile, CMakeRunner.Listener cmakeListener) {
+        this(conanCommand, conanProfile, cmakeListener, null);
     }
 
-    private AsyncConanCommand(@Nullable Project project, ConanProfile conanProfile, @Nullable CMakeRunner.Listener cmakeListener, @Nullable ProcessListener processListener, String... args) {
-        super(project, args);
-        this.conanTask = new AsyncConanTask(project, conanProfile, cmakeListener, processListener, super.args);
+    AsyncConanCommand(ConanCommandBase conanCommand, ConanProfile conanProfile, ProcessListener processListener) {
+        this(conanCommand, conanProfile, null, processListener);
+    }
+
+    private AsyncConanCommand(ConanCommandBase conanCommand, ConanProfile conanProfile, @Nullable CMakeRunner.Listener cmakeListener, @Nullable ProcessListener processListener) {
+        this.conanTask = new AsyncConanTask(conanCommand.project, conanProfile, cmakeListener, processListener, conanCommand.args);
     }
 
     @Override

--- a/src/main/java/conan/commands/AsyncConanCommand.java
+++ b/src/main/java/conan/commands/AsyncConanCommand.java
@@ -19,10 +19,6 @@ public class AsyncConanCommand implements Runnable {
 
     private AsyncConanTask conanTask;
 
-    AsyncConanCommand(ConanCommandBase conanCommand) {
-        this(conanCommand, null, null, null);
-    }
-
     AsyncConanCommand(ConanCommandBase conanCommand, ConanProfile conanProfile) {
         this(conanCommand, conanProfile, null, null);
     }
@@ -31,7 +27,7 @@ public class AsyncConanCommand implements Runnable {
         this(conanCommand, conanProfile, cmakeListener, null);
     }
 
-    AsyncConanCommand(ConanCommandBase conanCommand, ConanProfile conanProfile, ProcessListener processListener) {
+    public AsyncConanCommand(ConanCommandBase conanCommand, ConanProfile conanProfile, ProcessListener processListener) {
         this(conanCommand, conanProfile, null, processListener);
     }
 

--- a/src/main/java/conan/commands/CleanCache.java
+++ b/src/main/java/conan/commands/CleanCache.java
@@ -9,12 +9,14 @@ import com.intellij.openapi.project.Project;
  *
  * Created by Yahav Itzhak on Feb 2018.
  */
-public class CleanCache extends AsyncConanCommand {
+public class CleanCache extends ConanCommandBase {
     public CleanCache(Project project) {
         super(project, "remove", "*", "-f");
     }
 
-    public CleanCache(Project project, ProcessListener processListener) {
-        super(project, null, processListener,"remove", "*", "-f");
+    public void run(ProcessListener processListener) {
+        AsyncConanCommand asyncCommand = new AsyncConanCommand(this, null, processListener);
+        asyncCommand.run();
     }
+
 }

--- a/src/main/java/conan/commands/ConanCommandBase.java
+++ b/src/main/java/conan/commands/ConanCommandBase.java
@@ -17,13 +17,16 @@ import static conan.utils.Utils.log;
  *
  * Created by Yahav Itzhak on Feb 2018.
  */
-abstract class ConanCommandBase implements Runnable {
+public class ConanCommandBase {
 
     private static final Logger logger = Logger.getInstance(ConanCommandBase.class);
 
+    Project project;
     GeneralCommandLine args;
 
-    ConanCommandBase(Project project, String... args) {
+    protected ConanCommandBase(Project project, String... args) {
+        this.project = project;
+
         ConanProjectSettings conanProjectSettings = ConanProjectSettings.getInstance(project);
         String envExePath = System.getenv("CONAN_EXE_PATH");
         if(envExePath != null){

--- a/src/main/java/conan/commands/Config.java
+++ b/src/main/java/conan/commands/Config.java
@@ -9,8 +9,12 @@ import com.intellij.openapi.project.Project;
  * <p>
  * Created by Yahav Itzhak on Feb 2018.
  */
-public class Config extends SyncConanCommand {
+public class Config extends ConanCommandBase {
     public Config(Project p) {
-        super(p, new ProcessAdapter(){}, "config");
+        super(p, "config");
+    }
+
+    public void run() {
+        new SyncConanCommand(this, new ProcessAdapter(){}).run();
     }
 }

--- a/src/main/java/conan/commands/ConfigInstall.java
+++ b/src/main/java/conan/commands/ConfigInstall.java
@@ -9,9 +9,13 @@ import com.intellij.openapi.project.Project;
  *
  * Created by Yahav Itzhak on Feb 2018.
  */
-public class ConfigInstall extends AsyncConanCommand {
+public class ConfigInstall extends ConanCommandBase {
 
-    public ConfigInstall(Project project, ProcessListener processListener, String source) {
-        super(project, null, processListener, "config", "install", source);
+    public ConfigInstall(Project project, String source) {
+        super(project, "config", "install", source);
+    }
+
+    public void run(ProcessListener processListener) {
+        new AsyncConanCommand(this, null, processListener).run();
     }
 }

--- a/src/main/java/conan/commands/Install.java
+++ b/src/main/java/conan/commands/Install.java
@@ -20,19 +20,10 @@ import java.util.Arrays;
  * <p>
  * Created by Yahav Itzhak on Feb 2018.
  */
-public class Install extends AsyncConanCommand {
+public class Install extends ConanCommandBase {
 
     public Install(Project project, CMakeProfile cMakeProfile, ConanProfile conanProfile, boolean update) {
-        this(project, (ProcessListener) null, cMakeProfile, conanProfile, update);
-    }
-
-    public Install(Project project, ProcessListener processListener, CMakeProfile cMakeProfile, ConanProfile conanProfile, boolean update) {
-        super(project, conanProfile, processListener, "install", project.getBasePath(), "-if=" + cMakeProfile.getTargetDir(), "-pr=" + conanProfile.getName());
-        addArguments(project, update);
-    }
-
-    public Install(Project project, CMakeRunner.Listener listener, CMakeProfile cMakeProfile, ConanProfile conanProfile, boolean update) {
-        super(project, conanProfile, listener, "install", project.getBasePath(), "-if=" + cMakeProfile.getTargetDir(), "-pr=" + conanProfile.getName());
+        super(project, "install", project.getBasePath(), "-if=" + cMakeProfile.getTargetDir(), "-pr=" + conanProfile.getName());
         addArguments(project, update);
     }
 
@@ -45,5 +36,17 @@ public class Install extends AsyncConanCommand {
         if (ArrayUtils.isNotEmpty(tokens)) {
             Arrays.stream(tokens).forEach(super::addParameter);
         }
+    }
+
+    public void run(ProcessListener processListener, ConanProfile conanProfile) {
+        new AsyncConanCommand(this, conanProfile, processListener).run();
+    }
+
+    public void run(CMakeRunner.Listener listener, ConanProfile conanProfile) {
+        new AsyncConanCommand(this, conanProfile, listener).run();
+    }
+
+    public void run(ConanProfile conanProfile) {
+        new AsyncConanCommand(this, conanProfile).run();
     }
 }

--- a/src/main/java/conan/commands/IsInstalledCommand.java
+++ b/src/main/java/conan/commands/IsInstalledCommand.java
@@ -16,13 +16,14 @@ import static conan.utils.Utils.log;
  *
  * Created by Yahav Itzhak on Feb 2018.
  */
-public class IsInstalledCommand extends ConanCommandBase {
+public class IsInstalledCommand implements Runnable {
 
     private static final Logger logger = Logger.getInstance(IsInstalledCommand.class);
     private boolean isInstalled;
+    private ConanCommandBase conanCommand;
 
     public IsInstalledCommand(Project project) {
-        super(project);
+        this.conanCommand = new ConanCommandBase(project);
     }
 
     @Override
@@ -41,7 +42,7 @@ public class IsInstalledCommand extends ConanCommandBase {
     private boolean isConanInstalled() {
         ProcessHandler processHandler;
         try {
-            processHandler = new OSProcessHandler(args);
+            processHandler = new OSProcessHandler(this.conanCommand.args);
             processHandler.startNotify();
             return processHandler.waitFor();
         } catch (ExecutionException e) {

--- a/src/main/java/conan/commands/NewProfile.java
+++ b/src/main/java/conan/commands/NewProfile.java
@@ -10,9 +10,13 @@ import conan.profiles.ConanProfile;
  *
  * Created by Yahav Itzhak on Feb 2018.
  */
-public class NewProfile extends AsyncConanCommand {
+public class NewProfile extends ConanCommandBase {
 
-    public NewProfile(Project project, ProcessListener processListener, ConanProfile conanProfile) {
-        super(project, null, processListener, "profile", "new", conanProfile.getName());
+    public NewProfile(Project project, ConanProfile conanProfile) {
+        super(project, "profile", "new", conanProfile.getName());
+    }
+
+    public void run(ProcessListener processListener) {
+        new AsyncConanCommand(this, null, processListener).run();
     }
 }

--- a/src/main/java/conan/commands/Search.java
+++ b/src/main/java/conan/commands/Search.java
@@ -9,9 +9,13 @@ import com.intellij.openapi.project.Project;
  *
  * Created by Yahav Itzhak on Feb 2018.
  */
-public class Search extends AsyncConanCommand {
+public class Search extends ConanCommandBase {
 
-    public Search(Project project, ProcessListener processListener) {
-        super(project, null, processListener, "search", "--raw");
+    public Search(Project project) {
+        super(project, "search", "--raw");
+    }
+
+    public void run(ProcessListener processListener) {
+        new AsyncConanCommand(this, null, processListener).run();
     }
 }

--- a/src/main/java/conan/commands/SyncConanCommand.java
+++ b/src/main/java/conan/commands/SyncConanCommand.java
@@ -21,6 +21,7 @@ public class SyncConanCommand implements Runnable {
         conanTask = new SyncConanTask(conanCommand.project, processListener, conanCommand.args);
     }
 
+    @Override
     public void run() {
         // The progress manager is only good for foreground threads.
         if (SwingUtilities.isEventDispatchThread()) {

--- a/src/main/java/conan/commands/SyncConanCommand.java
+++ b/src/main/java/conan/commands/SyncConanCommand.java
@@ -13,13 +13,12 @@ import javax.swing.*;
  *
  * Created by Yahav Itzhak on Feb 2018.
  */
-public abstract class SyncConanCommand extends ConanCommandBase {
+public class SyncConanCommand implements Runnable {
 
     private SyncConanTask conanTask;
 
-    protected SyncConanCommand(Project project, @Nullable ProcessListener processListener, String... args) {
-        super(project, args);
-        conanTask = new SyncConanTask(project, processListener, super.args);
+    public SyncConanCommand(ConanCommandBase conanCommand, @Nullable ProcessListener processListener) {
+        conanTask = new SyncConanTask(conanCommand.project, processListener, conanCommand.args);
     }
 
     public void run() {

--- a/src/main/java/conan/commands/Version.java
+++ b/src/main/java/conan/commands/Version.java
@@ -8,8 +8,12 @@ import com.intellij.openapi.project.Project;
  * <p>
  * Created by Yahav Itzhak on Jan 2019.
  */
-public class Version extends SyncConanCommand {
+public class Version extends ConanCommandBase {
     public Version(Project project) {
-        super(project, null, "-v");
+        super(project, "-v");
+    }
+
+    public void run() {
+        new SyncConanCommand(this, null).run();
     }
 }

--- a/src/main/java/conan/commands/listProfiles/GetConanProfiles.java
+++ b/src/main/java/conan/commands/listProfiles/GetConanProfiles.java
@@ -1,6 +1,7 @@
 package conan.commands.listProfiles;
 
 import com.intellij.openapi.project.Project;
+import conan.commands.ConanCommandBase;
 import conan.commands.SyncConanCommand;
 import conan.profiles.ConanProfile;
 
@@ -12,9 +13,13 @@ import java.util.List;
  *
  * Created by Yahav Itzhak on Feb 2018.
  */
-public class GetConanProfiles extends SyncConanCommand {
+public class GetConanProfiles extends ConanCommandBase {
 
-    public GetConanProfiles(List<ConanProfile> profiles, Project project) {
-        super(project, new GetConanProfilesProcessListener(profiles), "profile", "list");
+    public GetConanProfiles(Project project) {
+        super(project, "profile", "list");
+    }
+
+    public void run(List<ConanProfile> profiles) {
+        new SyncConanCommand(this, new GetConanProfilesProcessListener(profiles)).run();
     }
 }

--- a/src/main/java/conan/commands/listProfiles/GetConanProfilesProcessListener.java
+++ b/src/main/java/conan/commands/listProfiles/GetConanProfilesProcessListener.java
@@ -15,12 +15,12 @@ import java.util.List;
  *
  * Created by Yahav Itzhak on Feb 2018.
  */
-class GetConanProfilesProcessListener extends ProcessAdapter {
+public class GetConanProfilesProcessListener extends ProcessAdapter {
 
     private static final String NO_PROFILES_STR = "No profiles defined";
     private List<ConanProfile> profiles;
 
-    GetConanProfilesProcessListener(List<ConanProfile> profiles) {
+    public GetConanProfilesProcessListener(List<ConanProfile> profiles) {
         this.profiles = profiles;
     }
 

--- a/src/main/java/conan/extensions/CMakeRunnerStepImpl.java
+++ b/src/main/java/conan/extensions/CMakeRunnerStepImpl.java
@@ -36,7 +36,7 @@ public class CMakeRunnerStepImpl implements CMakeRunnerStep {
         }
         ConanProfile conanProfile = profileMatching.get(cmakeProfile);
         if (StringUtils.isNotBlank(conanProfile.getName())) {
-            new Install(project, parameters.getListener(), cmakeProfile, conanProfile, false).run();
+            new Install(project, cmakeProfile, conanProfile, false).run(parameters.getListener(), conanProfile);
         }
     }
 

--- a/src/main/java/conan/profiles/ProfileUtils.java
+++ b/src/main/java/conan/profiles/ProfileUtils.java
@@ -35,7 +35,7 @@ public class ProfileUtils {
         List<ConanProfile> profiles = Lists.newArrayList();
         // Prevents "Remotes registry file missing" message
         new Config(project).run();
-        new GetConanProfiles(profiles, project).run();
+        new GetConanProfiles(project).run(profiles);
         return profiles;
     }
 

--- a/src/main/java/conan/ui/configuration/ConanConfig.java
+++ b/src/main/java/conan/ui/configuration/ConanConfig.java
@@ -123,7 +123,7 @@ public class ConanConfig implements Configurable, Configurable.NoScroll {
                 }
             }
         };
-        new ConfigInstall(this.project, processListener, source).run();
+        new ConfigInstall(this.project, source).run(processListener);
     }
 
     private void setConfigInstallRes(String results, boolean isSuccess) {

--- a/src/test/java/conan/testUtils/Utils.java
+++ b/src/test/java/conan/testUtils/Utils.java
@@ -8,12 +8,14 @@ import com.intellij.openapi.progress.DumbProgressIndicator;
 import com.intellij.openapi.project.Project;
 import conan.commands.*;
 import conan.commands.listProfiles.GetConanProfiles;
+import conan.commands.listProfiles.GetConanProfilesProcessListener;
 import conan.commands.task.AsyncConanTask;
 import conan.commands.task.SyncConanTask;
 import conan.profiles.CMakeProfile;
 import conan.profiles.ConanProfile;
 import org.testng.Assert;
 
+import javax.rmi.CORBA.Util;
 import java.io.File;
 import java.util.HashSet;
 import java.util.List;
@@ -42,37 +44,50 @@ public class Utils {
 
     public static void installPocoProject(File installationDir) {
         CMakeProfile cMakeProfile = new CMakeProfile("poco-timer", installationDir);
-        AsyncConanCommand install = new Install(new OpenSSLProjectImpl(), new ProcessAdapter(){}, cMakeProfile, DEFAULT_CONAN_PROFILE, false);
-        install.addParameter("--build=missing");
+        Install installCommand = new Install(new OpenSSLProjectImpl(), cMakeProfile, DEFAULT_CONAN_PROFILE, false);
+        installCommand.addParameter("--build=missing");
+        AsyncConanCommand install = new AsyncConanCommand(installCommand, DEFAULT_CONAN_PROFILE, new ProcessAdapter(){});
         Utils.runConanCommand(install);
     }
 
     public static void verifyPackages(Set<String> expectedPackages) {
-        AsyncConanCommand search = new Search(new OpenSSLProjectImpl(), new ConanPackagesVerifier(expectedPackages));
+        ConanCommandBase conanCommand = new Search(new OpenSSLProjectImpl());
+        AsyncConanCommand search = new AsyncConanCommand(conanCommand, null, new ConanPackagesVerifier(expectedPackages));
         Utils.runConanCommand(search);
     }
 
     public static void cleanCache() {
-        AsyncConanCommand cleanCache = new CleanCache(new OpenSSLProjectImpl(), new ProcessAdapter(){});
+        ConanCommandBase conanCommandBase = new CleanCache(new OpenSSLProjectImpl());
+        AsyncConanCommand cleanCache = new AsyncConanCommand(conanCommandBase, null, new ProcessAdapter(){});
         Utils.runConanCommand(cleanCache);
     }
 
     public static void verifyProfiles(Set<ConanProfile> expectedProfiles, Project project) {
         List<ConanProfile> conanProfiles = Lists.newArrayList();
-        Utils.runConanCommand(new Config(project)); // Prevents "Remotes registry file missing" message
-        Utils.runConanCommand(new GetConanProfiles(conanProfiles, project));
+
+        // Prevents "Remotes registry file missing" message
+        ConanCommandBase config = new Config(project);
+        SyncConanCommand syncCommand = new SyncConanCommand(config, new ProcessAdapter(){});
+        Utils.runConanCommand(syncCommand);
+
+        ConanCommandBase getConanProfiles = new GetConanProfiles(project);
+        SyncConanCommand syncConanCommand = new SyncConanCommand(getConanProfiles, new GetConanProfilesProcessListener(conanProfiles));
+        Utils.runConanCommand(syncConanCommand);
+
         Assert.assertEquals(Sets.newHashSet(conanProfiles), expectedProfiles);
     }
 
     public static void configInstall(Project project, String source) {
-        AsyncConanCommand configInstall = new ConfigInstall(project, new ProcessAdapter(){}, source);
-        Utils.runConanCommand(configInstall);
+        ConanCommandBase configInstall = new ConfigInstall(new OpenSSLProjectImpl(), source);
+        AsyncConanCommand asyncConanCommand = new AsyncConanCommand(configInstall, null, new ProcessAdapter(){});
+        Utils.runConanCommand(asyncConanCommand);
     }
 
     public static void createProfiles(Set<ConanProfile> newProfiles) {
         newProfiles.forEach(newProfile -> {
-            AsyncConanCommand newProfileCommand = new NewProfile(new OpenSSLProjectImpl(), new ProcessAdapter(){}, newProfile);
-            Utils.runConanCommand(newProfileCommand);
+            ConanCommandBase newProfileCommand = new NewProfile(new OpenSSLProjectImpl(), newProfile);
+            AsyncConanCommand asyncConanCommand = new AsyncConanCommand(newProfileCommand, null, new ProcessAdapter(){});
+            Utils.runConanCommand(asyncConanCommand);
         });
     }
 


### PR DESCRIPTION
This PR is a first step trying to make more flexible the hierarchy of Conan commands. It decouples the context (sync/async) from the command itself (although, in order to minimize changes, there is a `run` method that implements the previous context). 

Once it is decoupled, any command can run in any context and it is the caller/consumer, the one that has to select or provide the context.

 * Commands are the abstraction between Java code and Conan CLI, we have to keep in mind that different users may have different Conan versions, Conan can change CLI,... and in the future we may need to parse Conan output. **We need this layer**.

We get a hierarchy for the commands:

![image](https://user-images.githubusercontent.com/1406456/65262058-cc487500-db09-11e9-9ff3-e8cd7692a572.png)

And a hierarchy for helper classes

![image](https://user-images.githubusercontent.com/1406456/65262104-e2eecc00-db09-11e9-93dc-041b5a13e936.png)


Work to do:

- [ ] Reorganize commands package
- [ ] Rethink about tasks and listeners
