### PR TITLE
Run Install command in CMake context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 .project
 .settings/
 bin/
+out/

--- a/src/main/java/conan/commands/ConanCommandBase.java
+++ b/src/main/java/conan/commands/ConanCommandBase.java
@@ -84,4 +84,8 @@ public class ConanCommandBase {
         }
     }
 
+    public GeneralCommandLine getCommandLine() {
+        return args;
+    }
+
 }

--- a/src/main/java/conan/commands/ConanCommandBase.java
+++ b/src/main/java/conan/commands/ConanCommandBase.java
@@ -11,11 +11,14 @@ import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.text.StringUtil;
 import com.jetbrains.cidr.cpp.cmake.CMakeRunner;
+import com.jetbrains.cidr.cpp.cmake.CMakeRunnerStep;
 import conan.commands.task.AsyncConanTask;
+import conan.commands.task.CMakeEnvironmentTask;
 import conan.commands.task.SyncConanTask;
 import conan.persistency.settings.ConanProjectSettings;
 import conan.profiles.ConanProfile;
 import conan.utils.Utils;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
@@ -72,6 +75,11 @@ public class ConanCommandBase {
         }
         SyncConanTask task = new SyncConanTask(this.project, processListener, this.args);
         this.run(task);
+    }
+
+    public void run_cmake_environment(@NotNull CMakeRunnerStep.Parameters parameters) {
+        CMakeEnvironmentTask task = new CMakeEnvironmentTask(this.args);
+        task.run(parameters);
     }
 
     public void run(Task task) {

--- a/src/main/java/conan/commands/task/CMakeEnvironmentTask.java
+++ b/src/main/java/conan/commands/task/CMakeEnvironmentTask.java
@@ -1,0 +1,67 @@
+package conan.commands.task;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.process.BaseProcessHandler;
+import com.intellij.execution.process.ProcessOutput;
+import com.intellij.openapi.progress.ProcessCanceledException;
+import com.intellij.openapi.util.ShutDownTracker;
+import com.jetbrains.cidr.PredefinedVariables;
+import com.jetbrains.cidr.cpp.cmake.CMakeRunnerStep;
+import com.jetbrains.cidr.cpp.toolchains.CPPEnvironment;
+import com.jetbrains.cidr.lang.toolchains.CidrToolEnvironment;
+import com.jetbrains.cidr.system.HostMachine;
+import com.jetbrains.cidr.toolchains.CidrToolsUtil;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Iterator;
+
+
+public class CMakeEnvironmentTask {
+
+    private GeneralCommandLine commandLine;
+
+    public CMakeEnvironmentTask(GeneralCommandLine commandLine) {
+        this.commandLine = commandLine;
+    }
+
+    public void run(@NotNull CMakeRunnerStep.Parameters parameters) {
+        commandLine.withParentEnvironmentType(parameters.isPassSystemEnvironment() ? GeneralCommandLine.ParentEnvironmentType.CONSOLE : GeneralCommandLine.ParentEnvironmentType.NONE);
+
+        Iterator var12 = PredefinedVariables.getIDEVariables().iterator();
+        while(var12.hasNext()) {
+            String var11 = (String)var12.next();
+            commandLine.withEnvironment(var11, "TRUE");
+        }
+        commandLine.getEnvironment().putAll(parameters.getAdditionalEnvironment());
+        commandLine.setWorkDirectory(parameters.getOutputDir().toFile());
+
+        commandLine.setRedirectErrorStream(true); // TODO: Check
+
+        CPPEnvironment environment = parameters.getEnvironment();
+        try {
+            environment.prepare(commandLine, CidrToolEnvironment.PrepareFor.BUILD);
+            final HostMachine hostMachine = environment.getHostMachine();
+            final BaseProcessHandler baseProcessHandler;
+            baseProcessHandler = hostMachine.createProcess(commandLine, false, false);
+            Runnable runnable = () -> hostMachine.killProcessTree(baseProcessHandler);
+            ShutDownTracker.getInstance().registerShutdownTask(runnable);
+
+            try {
+                parameters.getListener().processStarted(baseProcessHandler);
+                ProcessOutput processOutput = CidrToolsUtil.runWithProgress(baseProcessHandler, 0);
+                if (processOutput.isCancelled()) {
+                    throw new ProcessCanceledException();
+                }
+            }
+            finally {
+                ShutDownTracker.getInstance().unregisterShutdownTask(runnable);
+                runnable.run();
+            }
+        }
+        catch (ExecutionException e) {
+            // TODO: What to do?
+        }
+
+    }
+}

--- a/src/main/java/conan/commands/task/CMakeEnvironmentTask.java
+++ b/src/main/java/conan/commands/task/CMakeEnvironmentTask.java
@@ -28,10 +28,10 @@ public class CMakeEnvironmentTask {
     public void run(@NotNull CMakeRunnerStep.Parameters parameters) {
         commandLine.withParentEnvironmentType(parameters.isPassSystemEnvironment() ? GeneralCommandLine.ParentEnvironmentType.CONSOLE : GeneralCommandLine.ParentEnvironmentType.NONE);
 
-        Iterator var12 = PredefinedVariables.getIDEVariables().iterator();
-        while(var12.hasNext()) {
-            String var11 = (String)var12.next();
-            commandLine.withEnvironment(var11, "TRUE");
+        Iterator itIDEVariables = PredefinedVariables.getIDEVariables().iterator();
+        while(itIDEVariables.hasNext()) {
+            String variable = (String)itIDEVariables.next();
+            commandLine.withEnvironment(variable, "TRUE");
         }
         commandLine.getEnvironment().putAll(parameters.getAdditionalEnvironment());
         commandLine.setWorkDirectory(parameters.getOutputDir().toFile());

--- a/src/main/java/conan/extensions/CMakeRunnerStepImpl.java
+++ b/src/main/java/conan/extensions/CMakeRunnerStepImpl.java
@@ -72,11 +72,7 @@ public class CMakeRunnerStepImpl implements CMakeRunnerStep {
                 final HostMachine hostMachine = environment.getHostMachine();
                 final BaseProcessHandler baseProcessHandler;
                 baseProcessHandler = hostMachine.createProcess(commandLine, false, false);
-                Runnable runnable = new Runnable() {
-                    public void run() {
-                        hostMachine.killProcessTree(baseProcessHandler);
-                    }
-                };
+                Runnable runnable = () -> hostMachine.killProcessTree(baseProcessHandler);
                 ShutDownTracker.getInstance().registerShutdownTask(runnable);
 
                 try {

--- a/src/main/java/conan/extensions/CMakeRunnerStepImpl.java
+++ b/src/main/java/conan/extensions/CMakeRunnerStepImpl.java
@@ -1,21 +1,10 @@
 package conan.extensions;
 
-import com.intellij.execution.ExecutionException;
-import com.intellij.execution.configurations.GeneralCommandLine;
-import com.intellij.execution.process.BaseProcessHandler;
-import com.intellij.execution.process.ProcessOutput;
-import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.ShutDownTracker;
 import com.intellij.openapi.util.io.FileUtil;
-import com.jetbrains.cidr.PredefinedVariables;
 import com.jetbrains.cidr.cpp.cmake.CMakeRunnerStep;
 import com.jetbrains.cidr.cpp.cmake.model.CMakeModelConfigurationData;
 import com.jetbrains.cidr.cpp.cmake.workspace.CMakeWorkspace;
-import com.jetbrains.cidr.cpp.toolchains.CPPEnvironment;
-import com.jetbrains.cidr.lang.toolchains.CidrToolEnvironment;
-import com.jetbrains.cidr.system.HostMachine;
-import com.jetbrains.cidr.toolchains.CidrToolsUtil;
 import conan.commands.ConanCommandBase;
 import conan.commands.Install;
 import conan.persistency.settings.ConanProjectSettings;
@@ -24,7 +13,6 @@ import conan.profiles.ConanProfile;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Iterator;
 import java.util.Map;
 
 /**
@@ -50,46 +38,7 @@ public class CMakeRunnerStepImpl implements CMakeRunnerStep {
         ConanProfile conanProfile = profileMatching.get(cmakeProfile);
         if (StringUtils.isNotBlank(conanProfile.getName())) {
             ConanCommandBase conanCommand = new Install(project, cmakeProfile, conanProfile, false);
-
-            // TODO: Change background task message to inform the user that Conan is running
-            // We need to run that command in the same environment as CMake
-            GeneralCommandLine commandLine = conanCommand.getCommandLine();
-            commandLine.withParentEnvironmentType(parameters.isPassSystemEnvironment() ? GeneralCommandLine.ParentEnvironmentType.CONSOLE : GeneralCommandLine.ParentEnvironmentType.NONE);
-
-            Iterator var12 = PredefinedVariables.getIDEVariables().iterator();
-            while(var12.hasNext()) {
-                String var11 = (String)var12.next();
-                commandLine.withEnvironment(var11, "TRUE");
-            }
-            commandLine.getEnvironment().putAll(parameters.getAdditionalEnvironment());
-            commandLine.setWorkDirectory(parameters.getOutputDir().toFile());
-
-            commandLine.setRedirectErrorStream(true); // TODO: Check
-
-            CPPEnvironment environment = parameters.getEnvironment();
-            try {
-                environment.prepare(commandLine, CidrToolEnvironment.PrepareFor.BUILD);
-                final HostMachine hostMachine = environment.getHostMachine();
-                final BaseProcessHandler baseProcessHandler;
-                baseProcessHandler = hostMachine.createProcess(commandLine, false, false);
-                Runnable runnable = () -> hostMachine.killProcessTree(baseProcessHandler);
-                ShutDownTracker.getInstance().registerShutdownTask(runnable);
-
-                try {
-                    parameters.getListener().processStarted(baseProcessHandler);
-                    ProcessOutput processOutput = CidrToolsUtil.runWithProgress(baseProcessHandler, 0);
-                    if (processOutput.isCancelled()) {
-                        throw new ProcessCanceledException();
-                    }
-                }
-                finally {
-                    ShutDownTracker.getInstance().unregisterShutdownTask(runnable);
-                    runnable.run();
-                }
-            }
-            catch (ExecutionException e) {
-                // TODO: What to do?
-            }
+            conanCommand.run_cmake_environment(parameters);
         }
     }
 

--- a/src/main/java/conan/extensions/CMakeRunnerStepImpl.java
+++ b/src/main/java/conan/extensions/CMakeRunnerStepImpl.java
@@ -1,10 +1,22 @@
 package conan.extensions;
 
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.process.BaseProcessHandler;
+import com.intellij.execution.process.ProcessOutput;
+import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.ShutDownTracker;
 import com.intellij.openapi.util.io.FileUtil;
+import com.jetbrains.cidr.PredefinedVariables;
 import com.jetbrains.cidr.cpp.cmake.CMakeRunnerStep;
 import com.jetbrains.cidr.cpp.cmake.model.CMakeModelConfigurationData;
 import com.jetbrains.cidr.cpp.cmake.workspace.CMakeWorkspace;
+import com.jetbrains.cidr.cpp.toolchains.CPPEnvironment;
+import com.jetbrains.cidr.lang.toolchains.CidrToolEnvironment;
+import com.jetbrains.cidr.system.HostMachine;
+import com.jetbrains.cidr.toolchains.CidrToolsUtil;
+import conan.commands.ConanCommandBase;
 import conan.commands.Install;
 import conan.persistency.settings.ConanProjectSettings;
 import conan.profiles.CMakeProfile;
@@ -12,6 +24,7 @@ import conan.profiles.ConanProfile;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Iterator;
 import java.util.Map;
 
 /**
@@ -36,7 +49,51 @@ public class CMakeRunnerStepImpl implements CMakeRunnerStep {
         }
         ConanProfile conanProfile = profileMatching.get(cmakeProfile);
         if (StringUtils.isNotBlank(conanProfile.getName())) {
-            new Install(project, cmakeProfile, conanProfile, false).run_async(conanProfile, parameters.getListener(), null);
+            ConanCommandBase conanCommand = new Install(project, cmakeProfile, conanProfile, false);
+
+            // TODO: Change background task message to inform the user that Conan is running
+            // We need to run that command in the same environment as CMake
+            GeneralCommandLine commandLine = conanCommand.getCommandLine();
+            commandLine.withParentEnvironmentType(parameters.isPassSystemEnvironment() ? GeneralCommandLine.ParentEnvironmentType.CONSOLE : GeneralCommandLine.ParentEnvironmentType.NONE);
+
+            Iterator var12 = PredefinedVariables.getIDEVariables().iterator();
+            while(var12.hasNext()) {
+                String var11 = (String)var12.next();
+                commandLine.withEnvironment(var11, "TRUE");
+            }
+            commandLine.getEnvironment().putAll(parameters.getAdditionalEnvironment());
+            commandLine.setWorkDirectory(parameters.getOutputDir().toFile());
+
+            commandLine.setRedirectErrorStream(true); // TODO: Check
+
+            CPPEnvironment environment = parameters.getEnvironment();
+            try {
+                environment.prepare(commandLine, CidrToolEnvironment.PrepareFor.BUILD);
+                final HostMachine hostMachine = environment.getHostMachine();
+                final BaseProcessHandler baseProcessHandler;
+                baseProcessHandler = hostMachine.createProcess(commandLine, false, false);
+                Runnable runnable = new Runnable() {
+                    public void run() {
+                        hostMachine.killProcessTree(baseProcessHandler);
+                    }
+                };
+                ShutDownTracker.getInstance().registerShutdownTask(runnable);
+
+                try {
+                    parameters.getListener().processStarted(baseProcessHandler);
+                    ProcessOutput processOutput = CidrToolsUtil.runWithProgress(baseProcessHandler, 0);
+                    if (processOutput.isCancelled()) {
+                        throw new ProcessCanceledException();
+                    }
+                }
+                finally {
+                    ShutDownTracker.getInstance().unregisterShutdownTask(runnable);
+                    runnable.run();
+                }
+            }
+            catch (ExecutionException e) {
+                // TODO: What to do?
+            }
         }
     }
 


### PR DESCRIPTION
Built on top of #57

Command `conan install` is executed in the CMake context, using the same listener and environment:
 * output from Conan and CMake is shown: closes #27 
 * task can be canceled
 * the process is created in the `hostMachine`, up to my understanding this means that the process can run in a remote machine or any subsystem (Conan has to be installed there) <-- this is not a feature right now, but it is ok to have it in advance.