### PR TITLE
Background tasks from the Conan window can be canceled

### DIFF
--- a/src/main/java/conan/commands/task/AsyncConanTask.java
+++ b/src/main/java/conan/commands/task/AsyncConanTask.java
@@ -2,16 +2,17 @@ package conan.commands.task;
 
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
-import com.intellij.execution.process.OSProcessHandler;
-import com.intellij.execution.process.ProcessHandler;
-import com.intellij.execution.process.ProcessListener;
+import com.intellij.execution.process.*;
 import com.intellij.notification.NotificationType;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.ShutDownTracker;
 import com.jetbrains.cidr.cpp.cmake.CMakeRunner;
+import com.jetbrains.cidr.toolchains.CidrToolsUtil;
 import conan.profiles.ConanProfile;
 import conan.ui.ConanToolWindow;
 import org.jetbrains.annotations.NotNull;
@@ -47,17 +48,30 @@ public class AsyncConanTask extends Task.Backgroundable {
         try {
             String message = args.getCommandLineString();
             log(logger, message, "", NotificationType.INFORMATION);
-            ProcessHandler processHandler = new OSProcessHandler(args);
-            processHandler.startNotify();
-            if (processListener != null) {
-                processHandler.addProcessListener(processListener);
-            } else if (cmakeListener != null) {
-                cmakeListener.processStarted(processHandler);
-            } else if (getProject() != null){
-                ConanToolWindow conanToolWindow = ServiceManager.getService(getProject(), ConanToolWindow.class);
-                conanToolWindow.attachConsoleToProcess(processHandler, message, conanProfile);
+            BaseProcessHandler processHandler = new OSProcessHandler(args);
+
+            Runnable runnable = () -> OSProcessUtil.killProcessTree(processHandler.getProcess());
+            ShutDownTracker.getInstance().registerShutdownTask(runnable);
+
+            try {
+                if (processListener != null) {
+                    processHandler.addProcessListener(processListener);
+                } else if (cmakeListener != null) {
+                    cmakeListener.processStarted(processHandler);
+                } else if (getProject() != null) {
+                    ConanToolWindow conanToolWindow = ServiceManager.getService(getProject(), ConanToolWindow.class);
+                    conanToolWindow.attachConsoleToProcess(processHandler, "Running Conan...", conanProfile);
+                }
+                ProcessOutput processOutput = CidrToolsUtil.runWithProgress(processHandler, 0);
+                if (processOutput.isCancelled()) {
+                    throw new ProcessCanceledException();
+                }
             }
-            processHandler.waitFor();
+            finally {
+                ShutDownTracker.getInstance().unregisterShutdownTask(runnable);
+                runnable.run();
+            }
+
         } catch (ExecutionException e) {
             log(logger, e.getMessage(), Arrays.toString(e.getStackTrace()), NotificationType.ERROR);
         }


### PR DESCRIPTION
closes #59

Now background tasks can be canceled.

I took this code from the disassembly of the CMakeRunner class, it is the same approach as #58 applied to these async tasks (in a future refactor both snippets should probably be merged).