### PR TITLE
Fixed path and changed deprecated function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,6 @@ addons:
 
 install:
   - python3 --version
-  - python3 -m pip || curl -s https://bootstrap.pypa.io/get-pip.py | python3 - --user
-  - python3 -m pip install --user conan
+  - python3 -m pip3 || curl -s https://bootstrap.pypa.io/get-pip.py | python3 - --user
+  - python3 -m pip3 install --user conan
   - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7;

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,6 @@ addons:
 
 install:
   - python3 --version
-  - python3 -m pip3 || curl -s https://bootstrap.pypa.io/get-pip.py | python3 - --user
-  - python3 -m pip3 install --user conan
+  - python3 -m pip || curl https://bootstrap.pypa.io/2.7/get-pip.py --output get-pip.py | python3 - --user
+  - python3 -m pip install --user conan
   - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7;

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,7 @@ addons:
       - gcc-7
       - g++-7
       - python3-pip
+      - python3-setuptools
 
 install:
   - python3 --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,9 +74,9 @@ addons:
     packages:
       - gcc-7
       - g++-7
+      - python3-pip
 
 install:
   - python3 --version
-  - python3 -m pip || curl https://bootstrap.pypa.io/2.7/get-pip.py --output get-pip.py | python3 - --user
   - python3 -m pip install --user conan
   - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7;

--- a/src/main/java/conan/commands/ConanCommandBase.java
+++ b/src/main/java/conan/commands/ConanCommandBase.java
@@ -42,7 +42,7 @@ public class ConanCommandBase {
         this.project = project;
         log(logger, "Conan at: ", conanPath, NotificationType.INFORMATION);
         this.args = new GeneralCommandLine(Lists.asList(conanPath, args));
-        this.args.setWorkDirectory(project.getBaseDir().getCanonicalPath());
+        this.args.setWorkDirectory(project.getBasePath());
         String conanHome = Utils.getConanHomeEnv();
         if (conanHome != null) {
             this.args.withEnvironment(CONAN_HOME_ENV, conanHome);

--- a/src/main/java/conan/commands/task/CMakeEnvironmentTask.java
+++ b/src/main/java/conan/commands/task/CMakeEnvironmentTask.java
@@ -34,7 +34,7 @@ public class CMakeEnvironmentTask {
             commandLine.withEnvironment(variable, "TRUE");
         }
         commandLine.getEnvironment().putAll(parameters.getAdditionalEnvironment());
-        commandLine.setWorkDirectory(parameters.getOutputDir().toFile());
+        commandLine.setWorkDirectory(parameters.getProjectDir().toFile());
 
         commandLine.setRedirectErrorStream(true); // TODO: Check
 


### PR DESCRIPTION
Two small changes:

1) `getBaseDir` is deprecated, `getBasePath()` works just fine.
2) In the `CMakeEnvironmentTask` the `conan install` invocation run with a wrong `cwd` that is not the same `cwd` used when clicking the conan cube to install. The correct path should be the project one, because the "install directory" is already specified with `if` so I don't know why it was `getOutputDir`