### PR TITLE
Move config right

### DIFF
--- a/src/main/kotlin/com/jfrog/conan/clionplugin/toolWindow/ConanWindowFactory.kt
+++ b/src/main/kotlin/com/jfrog/conan/clionplugin/toolWindow/ConanWindowFactory.kt
@@ -175,8 +175,10 @@ class ConanWindowFactory : ToolWindowFactory {
                 val scrollablePane = JBScrollPane(packagesTable)
 
                 add(JBSplitter().apply {
-                    firstComponent = actionToolbar.component
-                    secondComponent = searchTextField
+                    firstComponent = searchTextField
+                    secondComponent = JPanel(BorderLayout()).apply {
+                        add(actionToolbar.component, BorderLayout.EAST)
+                    }
                 }, BorderLayout.PAGE_START)
                 add(scrollablePane, BorderLayout.CENTER)
             }


### PR DESCRIPTION
Like this:

<img width="496" alt="image" src="https://github.com/conan-io/conan-clion-plugin/assets/5045666/cf7a701f-db80-44dc-b600-9a1a776c3333">

Instead of having it on the left how it was previously:

![image](https://github.com/conan-io/conan-clion-plugin/assets/5045666/caddf8c2-7bda-471b-b827-33af3487e3cd)

