### PR TITLE
Continue improving instructions to use packages

### DIFF
--- a/src/main/kotlin/com/jfrog/conan/clionplugin/toolWindow/PackageInfoPanel.kt
+++ b/src/main/kotlin/com/jfrog/conan/clionplugin/toolWindow/PackageInfoPanel.kt
@@ -48,25 +48,22 @@ class PackageInfoPanel {
         return """
             function fillExtraData() {
                 const data = $targetsData;
+                const libraries = data["libraries"]
                 const cpp_info = document.getElementById("cpp_info");
                 cpp_info.innerText = "";
-                if ("$name" in data) {
-                    if ("cmake_file_name" in data["$name"]) {
-                        cpp_info.innerText += "cmake_file_name: " + data["$name"]["cmake_file_name"] + "\n";
+                let cmake_file_name = libraries["$name"]["cmake_file_name"] || "$name";
+                cpp_info.innerText += "cmake_file_name: " + cmake_file_name + "\n";
+
+                let cmake_target_name = libraries["$name"]["cmake_target_name"] || "$name::$name";
+                cpp_info.innerText += "cmake_target_name: " + cmake_target_name + "\n";
+
+                if ("components" in libraries["$name"]) {
+                    cpp_info.innerText += "components: ";
+                    for (let component in libraries["$name"]["components"]) {
+                        let cmake_target_name = libraries["$name"]["cmake_target_name"] || ("$name::" + component);
+                        cpp_info.innerText += "component: " + component + "\n";
+                        cpp_info.innerText += "cmake_target_name: " + cmake_target_name + "\n";
                     }
-                    if ("cmake_target_name" in data["$name"]) {
-                        cpp_info.innerText += "cmake_target_name: " + data["$name"]["cmake_target_name"] + "\n";
-                    }
-                    if ("components" in data["$name"]) {
-                        cpp_info.innerText += "components: ";
-                        for (let component in data["$name"]["components"]) {
-                            cpp_info.innerText += data["$name"]["components"][component]["cmake_target_name"] + "\n";
-                        }
-                    }
-                }
-                else {
-                    cpp_info.innerText += "cmake_file_name: $name\n";
-                    cpp_info.innerText += "cmake_target_name: $name::$name\n";
                 }
             }
         """.trimIndent()

--- a/src/main/kotlin/com/jfrog/conan/clionplugin/toolWindow/PackageInfoPanel.kt
+++ b/src/main/kotlin/com/jfrog/conan/clionplugin/toolWindow/PackageInfoPanel.kt
@@ -42,8 +42,17 @@ class PackageInfoPanel {
 
     fun getTitleHtml(name: String): String {
         val description = libraryData.libraries[name]?.description
-        return "<html>&nbsp;<strong><font size='11'>$name</font></strong><br>&nbsp;<font size='4'>$description</font><br><br>"
+        val licenses = libraryData.libraries[name]?.license
+        var html =  "<html>" +
+                "&nbsp;<strong><font size='11'>$name</font></strong><br>" +
+                "&nbsp;<font size='5'>$description</font>"
+        if (licenses!=null) {
+            html += "<br>&nbsp;<font size='6'>&#x2696;</font>&nbsp;<strong><font size='4'>${licenses.joinToString(", ")}</font></strong>"
+        }
+        html += "<br>"
+        return html
     }
+
 
     private fun getScript(name: String): String {
         return """

--- a/src/main/kotlin/com/jfrog/conan/clionplugin/toolWindow/PackageInfoPanel.kt
+++ b/src/main/kotlin/com/jfrog/conan/clionplugin/toolWindow/PackageInfoPanel.kt
@@ -57,9 +57,8 @@ class PackageInfoPanel {
                 let cmake_file_name = libraries[selected_lib]["cmake_file_name"] || selected_lib;
                 let cmake_target_name = libraries[selected_lib]["cmake_target_name"] || selected_lib + "::" + selected_lib;
 
-                // Check if the library is not compatible with Conan v2
                 if (libraries[selected_lib]["v2"] == false) {
-                    let warning = "<p><strong>Warning: This library is not compatible with Conan v2. If you need to use this library, please <a href='https://github.com/conan-io/conan-center-index/issues/new?title=Library " + selected_lib + " is not compatible with Conan v2&body=This issue comes from the Clion plugin'>open an issue in Conan Center Index</a>.</strong></p>";
+                    let warning = "<div class='warning'><span>&#x26A0;</span> Warning: This library is not compatible with Conan v2. If you need to use this library, please <a href='https://github.com/conan-io/conan-center-index/issues/new?title=Library " + selected_lib + " is not compatible with Conan v2&body=This issue comes from the Clion plugin'>open an issue in Conan Center Index</a>.</div>";
                     infoDiv.innerHTML += warning;
                 }
 
@@ -118,7 +117,8 @@ class PackageInfoPanel {
         val isDarkTheme = lafClassName.contains("Darcula", ignoreCase = true)
         val foregroundColor = if (isDarkTheme) Color(187, 187, 187) else Color(0, 0, 0)
         val backgroundColor = if (isDarkTheme) Color(60, 63, 65) else Color(242, 242, 242)
-        val linkColor = if (isDarkTheme) Color(187, 134, 252) else Color(0, 0, 238) // Puedes cambiar estos valores de color a lo que quieras.
+        val linkColor = if (isDarkTheme) Color(187, 134, 252) else Color(0, 0, 238)
+        val blockColor = if (isDarkTheme) Color(80, 80, 80) else Color(242, 242, 242)
 
         return """
             body {
@@ -134,13 +134,21 @@ class PackageInfoPanel {
                 text-decoration: underline;
             }
             .code {
-                background-color: ${if (isDarkTheme) "rgb(80, 80, 80)" else "rgb(242, 242, 242)"};
+                background-color: ${toCssColor(blockColor)};
                 padding: 10px;
                 border-radius: 5px;
                 overflow: auto;
                 white-space: pre;
                 line-height: 1.2;
                 font-size: 13px;
+            }
+            .warning {
+                background-color: ${toCssColor(blockColor)};
+                padding: 10px;
+                border-radius: 5px;
+                overflow: auto;
+                line-height: 1.2;
+                font-size: 14px;
             }
             """.trimIndent()
     }


### PR DESCRIPTION
Still missing some scrollbar when the content overflows the plugin panel. Looks like this:

<img width="1484" alt="image" src="https://github.com/conan-io/conan-clion-plugin/assets/5045666/d7998e87-96ba-4d2d-b098-555fb9ed3d84">

If the lib is not compatible with v2, there's a warning and you can open an issue directly from the plugin to Conan Center to ask for compatibility, I modified the content of the issue to track that the issue comes from the plugin but we also can use the title if we want to track that:

<img width="1241" alt="image" src="https://github.com/conan-io/conan-clion-plugin/assets/5045666/c7a8d59d-98f9-49f7-ae2c-09970a4a0b1b">
