### PR TITLE
Do not let users change version on combo if recipe already added to project

### DIFF
--- a/src/main/kotlin/com/jfrog/conan/clionplugin/toolWindow/PackageInformationPanel.kt
+++ b/src/main/kotlin/com/jfrog/conan/clionplugin/toolWindow/PackageInformationPanel.kt
@@ -63,6 +63,9 @@ class PackageInformationPanel(private val conanService: ConanService, private va
                 val isRequired = conanService.getRequirements().any { it.startsWith("$name/") }
                 addButton.isVisible = !isRequired
                 removeButton.isVisible = isRequired
+                comboBox.isEnabled = false
+                comboBox.setToolTipText(UIBundle.message("library.description.combo.disabled"))
+
                 Messages.showMessageDialog(
                         UIBundle.message("library.added.body", comboBox.selectedItem as String),
                         UIBundle.message("library.added.title"),
@@ -75,6 +78,8 @@ class PackageInformationPanel(private val conanService: ConanService, private va
                 val isRequired = conanService.getRequirements().any { it.startsWith("$name/") }
                 addButton.isVisible = !isRequired
                 removeButton.isVisible = isRequired
+                comboBox.isEnabled = true
+                comboBox.setToolTipText(null)
                 Messages.showMessageDialog(
                         UIBundle.message("library.removed.body", comboBox.selectedItem as String),
                         UIBundle.message("library.removed.title"),
@@ -85,6 +90,13 @@ class PackageInformationPanel(private val conanService: ConanService, private va
             val isRequired = conanService.getRequirements().any { it.startsWith("$name/") }
             addButton.isVisible = !isRequired
             removeButton.isVisible = isRequired
+            comboBox.isEnabled = !isRequired
+
+            if (isRequired) {
+                comboBox.setToolTipText(UIBundle.message("library.description.combo.disabled"))
+            } else {
+                comboBox.setToolTipText(null)
+            }
         }
 
         c.gridx = 0

--- a/src/main/kotlin/com/jfrog/conan/clionplugin/toolWindow/PackageInformationPanel.kt
+++ b/src/main/kotlin/com/jfrog/conan/clionplugin/toolWindow/PackageInformationPanel.kt
@@ -63,7 +63,7 @@ class PackageInformationPanel(private val conanService: ConanService, private va
                 val isRequired = conanService.getRequirements().any { it.startsWith("$name/") }
                 addButton.isVisible = !isRequired
                 removeButton.isVisible = isRequired
-                comboBox.isEnabled = false
+                comboBox.isEnabled = !isRequired
                 comboBox.setToolTipText(UIBundle.message("library.description.combo.disabled"))
 
                 Messages.showMessageDialog(
@@ -78,7 +78,7 @@ class PackageInformationPanel(private val conanService: ConanService, private va
                 val isRequired = conanService.getRequirements().any { it.startsWith("$name/") }
                 addButton.isVisible = !isRequired
                 removeButton.isVisible = isRequired
-                comboBox.isEnabled = true
+                comboBox.isEnabled = !isRequired
                 comboBox.setToolTipText(null)
                 Messages.showMessageDialog(
                         UIBundle.message("library.removed.body", comboBox.selectedItem as String),

--- a/src/main/kotlin/com/jfrog/conan/clionplugin/toolWindow/PackageInformationPanel.kt
+++ b/src/main/kotlin/com/jfrog/conan/clionplugin/toolWindow/PackageInformationPanel.kt
@@ -93,6 +93,9 @@ class PackageInformationPanel(private val conanService: ConanService, private va
             comboBox.isEnabled = !isRequired
 
             if (isRequired) {
+                val requirement = conanService.getRequirements().find { it.startsWith("$name/") }
+                val version = requirement?.split("/")?.get(1)
+                comboBox.selectedItem = version
                 comboBox.setToolTipText(UIBundle.message("library.description.combo.disabled"))
             } else {
                 comboBox.setToolTipText(null)

--- a/src/main/resources/messages/ui.properties
+++ b/src/main/resources/messages/ui.properties
@@ -29,6 +29,7 @@ library.removed.title=Library Removed From Project
 library.removed.body={0} removed from project
 library.description.button.install=Use in project
 library.description.button.remove=Remove from project
+library.description.combo.disabled=Please, to add another version of the library, first remove the existing one
 library.description.empty=No selection
 
 


### PR DESCRIPTION
Some improments in UI to not let users add multiple versions of the same package, the way to change the version is removing the package first and the adding a different version.