### PR TITLE
Hide html component scrollbar

### DIFF
--- a/src/main/kotlin/com/jfrog/conan/clionplugin/toolWindow/ReadmePanel.kt
+++ b/src/main/kotlin/com/jfrog/conan/clionplugin/toolWindow/ReadmePanel.kt
@@ -88,7 +88,14 @@ class ReadmePanel(val project: Project) {
         <html>
         <head>
             <style>
+                ::-webkit-scrollbar {
+                    display: none;
+                }
                 body {
+                    overflow: -moz-scrollbars-none;
+                    -ms-overflow-style: none;  /* IE and Edge */
+                }
+                html, body {
                     overflow: auto;
                 }
                 $themeStyles


### PR DESCRIPTION
For some cases like libraries with components with large content, the scrollbar appears in the html view, this PR removes that so only the scrollbar for the parent will appear. This image shows the problem:

<img width="1405" alt="image" src="https://github.com/conan-io/conan-clion-plugin/assets/5045666/12bce38b-0ac1-48da-9600-4815f5d54d5e">
