### PR TITLE
Update description and bump version to 2.0.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ pluginRepositoryUrl = https://github.com/conan-io/conan-clion-plugin/
 pluginVersion = 2.0.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 222
+pluginSinceBuild = 223
 pluginUntilBuild = 232.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.jfrog.conan.clion
 pluginName = Conan
 pluginRepositoryUrl = https://github.com/conan-io/conan-clion-plugin/
 # SemVer format -> https://semver.org
-pluginVersion = 2.0.0-beta.2
+pluginVersion = 2.0.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 222

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,15 +1,25 @@
 <!-- Plugin Configuration File. Read more: https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html -->
 <idea-plugin>
     <id>com.jfrog.conan.clion</id>
-    <name>Conan, C and C++ Package Manager</name>
+    <name>Conan</name>
     <vendor>JFrog</vendor>
+    <description><![CDATA[
+        <a href="https://conan.io/">Conan</a> package manager integration with CLion.
+        <br>
+        <br>
+        Features:
+        <ul>
+            <li>Browse all available Conan packages in Conan Center</li>
+            <li>Add selected dependencies and use conan.cmake dependency provider to automatically install them according to the CLion configuration</li>
+        </ul>
+        Links: <a href="https://blog.conan.io/introducing-new-conan-clion-plugin/">Getting started</a>
+        | <a href="https://github.com/conan-io/conan-clion-plugin/issues">Issue tracker</a>
+        <br>
+    ]]></description>
 
     <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.modules.clion</depends>
-
     <resource-bundle>messages.ui</resource-bundle>
-
-
     <extensions defaultExtensionNs="com.intellij">
         <toolWindow factoryClass="com.jfrog.conan.clion.toolWindow.ConanWindowFactory"
                     id="Conan"


### PR DESCRIPTION
Also raise min CLion version to 223 -> 2022.3 to make sure the bundled CMake version is compatible with dependency providers.