### PR TITLE
Fix adding support to new profiles when the autoadd option is True

### DIFF
--- a/src/main/kotlin/com/jfrog/conan/clion/listeners/ConanCMakeSettingsListener.kt
+++ b/src/main/kotlin/com/jfrog/conan/clion/listeners/ConanCMakeSettingsListener.kt
@@ -18,9 +18,10 @@ internal class ConanCMakeSettingsListener(private val project: Project) : CMakeS
         val properties = project.service<PropertiesComponent>()
         val autoAdd = (properties.getValue(PersistentStorageKeys.AUTOMATIC_ADD_CONAN, "false") == "true")
         if (autoAdd) {
-            // get only the new profiles
+            // Add only to new profiles, if old profiles don't have
+            // Conan support is because it was manually disabled
             current
-                .filter { new -> old.any { new.name == it.name }}
+                .filter { new -> old.none { new.name == it.name }}
                 .forEach { CMake(project).injectDependencyProviderToProfile(it.name) }
         }
     }


### PR DESCRIPTION
New profiles did not added the dependency provider, also this may fix: https://github.com/conan-io/conan-clion-plugin/issues/148 although still could not reproduce