### PR TITLE
Fix when only the conan executable path was modified in the Conan plugin configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## [Unreleased]
 
+### Bugfix
+- Fixed when only the Conan executable path was changed, it was not updated
+
 ## [2.0.1] - 2023-08-31
 
 ### Bugfix

--- a/src/main/kotlin/com/jfrog/conan/clion/cmake/CMake.kt
+++ b/src/main/kotlin/com/jfrog/conan/clion/cmake/CMake.kt
@@ -119,39 +119,6 @@ class CMake(val project: Project) {
         cmakeSettings.setProfiles(modifiedProfiles)
     }
 
-    fun checkConanExecutable(): Boolean {
-        val exeConfigured =
-            (project.service<PropertiesComponent>().getValue(PersistentStorageKeys.CONAN_EXECUTABLE, "") != "")
-        if (!exeConfigured) {
-            // TODO: still missing implementing the 'Use conan in system path' checkbox
-            Messages.showMessageDialog(
-                "Looks like you have not configured the path to the Conan executable," +
-                        " if you want to use the system one please check the 'Use conan in system path' " +
-                        "option in the configuration window.",
-                "Conan executable path not configured",
-                Messages.getWarningIcon()
-            )
-        }
-        return exeConfigured
-    }
-
-    fun addConanSupport() {
-        val profiles: MutableList<String> = mutableListOf()
-        if (checkConanExecutable()) {
-            getActiveProfiles().forEach { profile ->
-                thisLogger().info("Adding Conan configuration to ${profile.name}")
-                injectConanSupportToProfile(profile.name)
-                profiles.add(profile.name)
-            }
-            project.service<PropertiesComponent>().setValue(PersistentStorageKeys.AUTOMATIC_ADD_CONAN, true)
-            Messages.showMessageDialog(
-                "Conan support added for: ${profiles.joinToString(separator = ", ")}",
-                "Conan support added",
-                Messages.getInformationIcon()
-            )
-        }
-    }
-
     fun getActiveProfiles(): List<CMakeSettings.Profile> {
         return CMakeSettings.getInstance(project).activeProfiles
     }

--- a/src/main/kotlin/com/jfrog/conan/clion/cmake/CMake.kt
+++ b/src/main/kotlin/com/jfrog/conan/clion/cmake/CMake.kt
@@ -24,19 +24,14 @@ class CMake(val project: Project) {
     fun checkConanUsedInProfile(profileName: String?): Boolean {
         val cmakeSettings = CMakeSettings.getInstance(project)
         val profiles = cmakeSettings.profiles
-        val modifiedProfiles: MutableList<CMakeSettings.Profile> = mutableListOf()
 
         for (profile in profiles) {
             if (profile.name == profileName) {
                 val existingGenerationOptions = profile.generationOptions ?: ""
                 return listOf("CONAN_COMMAND", "conan_provider.cmake").any { existingGenerationOptions.contains(it) }
-            } else {
-                modifiedProfiles.add(profile)
             }
         }
-
-        cmakeSettings.setProfiles(modifiedProfiles)
-        return true
+        return false
     }
 
     fun injectConanSupportToProfile(profileName: String) {

--- a/src/main/kotlin/com/jfrog/conan/clion/cmake/CMake.kt
+++ b/src/main/kotlin/com/jfrog/conan/clion/cmake/CMake.kt
@@ -39,7 +39,7 @@ class CMake(val project: Project) {
         return true
     }
 
-    fun injectDependencyProviderToProfile(profileName: String) {
+    fun injectConanSupportToProfile(profileName: String) {
         val conanExecutable: String = project.service<PropertiesComponent>().getValue(
             PersistentStorageKeys.CONAN_EXECUTABLE,
             ""
@@ -53,7 +53,7 @@ class CMake(val project: Project) {
         addGenerationOptions(profileName, generationOptions)
     }
 
-    fun removeDependencyProviderFromProfile(profileName: String) {
+    fun removeConanSupportFromProfile(profileName: String) {
         removeGenerationOptions(
             profileName,
             listOf(
@@ -140,7 +140,7 @@ class CMake(val project: Project) {
         if (checkConanExecutable()) {
             getActiveProfiles().forEach { profile ->
                 thisLogger().info("Adding Conan configuration to ${profile.name}")
-                injectDependencyProviderToProfile(profile.name)
+                injectConanSupportToProfile(profile.name)
                 profiles.add(profile.name)
             }
             project.service<PropertiesComponent>().setValue(PersistentStorageKeys.AUTOMATIC_ADD_CONAN, true)

--- a/src/main/kotlin/com/jfrog/conan/clion/cmake/CMake.kt
+++ b/src/main/kotlin/com/jfrog/conan/clion/cmake/CMake.kt
@@ -45,6 +45,12 @@ class CMake(val project: Project) {
         if (conanExecutable != "" && conanExecutable != "conan") {
             generationOptions.add("-DCONAN_COMMAND=\"${conanExecutable}\"")
         }
+        else {
+            removeGenerationOptions(
+                profileName,
+                listOf("CONAN_COMMAND")
+            )
+        }
         addGenerationOptions(profileName, generationOptions)
     }
 

--- a/src/main/kotlin/com/jfrog/conan/clion/dialogs/ConanExecutableDialog.kt
+++ b/src/main/kotlin/com/jfrog/conan/clion/dialogs/ConanExecutableDialog.kt
@@ -182,9 +182,9 @@ class ConanExecutableDialogWrapper(val project: Project) : DialogWrapper(true) {
         profileCheckboxes.forEach { checkbox ->
             val profileName = checkbox.text
             if (checkbox.isSelected) {
-                cmake.injectDependencyProviderToProfile(profileName)
+                cmake.injectConanSupportToProfile(profileName)
             } else {
-                cmake.removeDependencyProviderFromProfile(profileName)
+                cmake.removeConanSupportFromProfile(profileName)
             }
         }
         properties

--- a/src/main/kotlin/com/jfrog/conan/clion/dialogs/ConanExecutableDialog.kt
+++ b/src/main/kotlin/com/jfrog/conan/clion/dialogs/ConanExecutableDialog.kt
@@ -171,8 +171,8 @@ class ConanExecutableDialogWrapper(val project: Project) : DialogWrapper(true) {
         else {
             properties.setValue(PersistentStorageKeys.CONAN_EXECUTABLE, "conan")
         }
-        val selected = if (automaticallyAddCheckbox.isSelected) "true" else "false"
-        properties.setValue(PersistentStorageKeys.AUTOMATIC_ADD_CONAN, selected)
+        val autoAddConan = if (automaticallyAddCheckbox.isSelected) "true" else "false"
+        properties.setValue(PersistentStorageKeys.AUTOMATIC_ADD_CONAN, autoAddConan)
 
         if (firstSetup) {
             conanService.downloadCMakeProvider()

--- a/src/main/kotlin/com/jfrog/conan/clion/listeners/ConanCMakeSettingsListener.kt
+++ b/src/main/kotlin/com/jfrog/conan/clion/listeners/ConanCMakeSettingsListener.kt
@@ -18,7 +18,7 @@ internal class ConanCMakeSettingsListener(private val project: Project) : CMakeS
             // Conan support is because it was manually disabled
             current
                 .filter { new -> old.none { new.name == it.name }}
-                .forEach { CMake(project).injectDependencyProviderToProfile(it.name) }
+                .forEach { CMake(project).injectConanSupportToProfile(it.name) }
         }
     }
 }


### PR DESCRIPTION
Fix when only the conan executable path was modified in the Conan plugin configuration, it was not taken into account
To reproduce:
- Add conan to project
- Reopen configuration and change the conan exe location -> it was not updated

Also
- Inject Conan to profile only when something changes
- Remove dead code: checkConanExecutable, addConanSupport
- Rename inject/removeDependencyProvider to inject/removeConanSupport as it was also handling the Conan exe