### PR TITLE
Use relative path for conan_provider.cmake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ## [2.0.1] - 2023-08-31
 
+### Changed
+- Use relative (instead of absolute) path to pass the conan_provider.cmake to CMake
+
 ### Bugfix
 - Fixed crash due to library data race condition when first using the plugin
 

--- a/src/main/kotlin/com/jfrog/conan/clion/cmake/CMake.kt
+++ b/src/main/kotlin/com/jfrog/conan/clion/cmake/CMake.kt
@@ -45,7 +45,7 @@ class CMake(val project: Project) {
             ""
         )
         val generationOptions: MutableList<String> = mutableListOf()
-        val conanProviderPath = project.service<ConanService>().getCMakeProviderFile().toString()
+        val conanProviderPath = project.service<ConanService>().getCMakeProviderFilename()
         generationOptions.add("-DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=\"${conanProviderPath}\"")
         if (conanExecutable != "" && conanExecutable != "conan") {
             generationOptions.add("-DCONAN_COMMAND=\"${conanExecutable}\"")

--- a/src/main/kotlin/com/jfrog/conan/clion/services/ConanService.kt
+++ b/src/main/kotlin/com/jfrog/conan/clion/services/ConanService.kt
@@ -146,7 +146,7 @@ class ConanService(val project: Project) {
         }
     }
 
-    private fun getCMakeProviderFilename(): String {
+    fun getCMakeProviderFilename(): String {
         return "conan_provider.cmake"
     }
 


### PR DESCRIPTION
Use relative path to pass the CMake provider instead of absolute
Closes: https://github.com/conan-io/conan-clion-plugin/issues/157