### PR TITLE
Fix adding multiple CONAN_COMMAND

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Bugfix
 - Fixed when only the Conan executable path was changed, it was not updated
+- Fixed adding multiple CONAN_COMMAND
 
 ## [2.0.1] - 2023-08-31
 

--- a/src/main/kotlin/com/jfrog/conan/clion/cmake/CMake.kt
+++ b/src/main/kotlin/com/jfrog/conan/clion/cmake/CMake.kt
@@ -72,14 +72,17 @@ class CMake(val project: Project) {
         for (profile in profiles) {
             if (profile.name == profileName) {
                 val existingGenerationOptions = profile.generationOptions ?: ""
-                val newGenerationOptions = mutableListOf<String>()
-
-                if (existingGenerationOptions.isNotEmpty()) {
-                    newGenerationOptions.add(existingGenerationOptions)
+                val newGenerationOptions = if (existingGenerationOptions.isNotEmpty()) {
+                    existingGenerationOptions.split(" ").toMutableList()
+                } else {
+                    mutableListOf<String>()
                 }
-
                 generationOptions.forEach { option ->
-                    if (!existingGenerationOptions.contains(option)) {
+                    val optionKey = option.split("=")[0]
+                    val existingOptionIndex = newGenerationOptions.indexOfFirst { it.startsWith(optionKey) }
+                    if (existingOptionIndex != -1) {
+                        newGenerationOptions[existingOptionIndex] = option
+                    } else {
                         newGenerationOptions.add(option)
                     }
                 }


### PR DESCRIPTION
To reproduce:
- Add conan suport to one profile with one custom conan exe location
- Change conan exe location and press OK -> two CONAN_COMMAND are present in the profile