### PR TITLE
Fix selection of Conan executable when named "conan.exe"

### DIFF
--- a/src/main/kotlin/com/jfrog/conan/plugin/dialogs/ConanExecutableDialog.kt
+++ b/src/main/kotlin/com/jfrog/conan/plugin/dialogs/ConanExecutableDialog.kt
@@ -34,7 +34,7 @@ object ConanExecutableChooserDescriptor : FileChooserDescriptor(true, true, fals
 
 val VirtualFile.isConanExecutable: Boolean
     get() {
-        return (extension == null || extension == "exe") && name == "conan"
+        return (extension == null || arrayOf("exe", "bat").contains(extension)) && name == "conan"
     }
 
 class ConanExecutableDialogWrapper(val project: Project) : DialogWrapper(true) {

--- a/src/main/kotlin/com/jfrog/conan/plugin/dialogs/ConanExecutableDialog.kt
+++ b/src/main/kotlin/com/jfrog/conan/plugin/dialogs/ConanExecutableDialog.kt
@@ -34,7 +34,7 @@ object ConanExecutableChooserDescriptor : FileChooserDescriptor(true, true, fals
 
 val VirtualFile.isConanExecutable: Boolean
     get() {
-        return (extension == null || arrayOf("exe", "bat").contains(extension)) && name == "conan"
+        return (extension == null || extension == "exe") && nameWithoutExtension == "conan"
     }
 
 class ConanExecutableDialogWrapper(val project: Project) : DialogWrapper(true) {


### PR DESCRIPTION
The file might be needed in Windows when it's used as a shim in pyenv

cc @jcar87 @juansblanco 

This does not fix the issue of CLion selecting an unwanted file when passed a relative file (when using the system conan), but helps fixing it by letting the use select the proper one