### PR TITLE
Fix deprecated usage errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Fixed deprecated usage of `ActionUpdateThread.OLD_EDT` by overriding `getActionUpdateThread()`
+
 ## [2.0.5] - 2024-08-14
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.jfrog.conan.clion
 pluginName = Conan
 pluginRepositoryUrl = https://github.com/conan-io/conan-clion-plugin/
 # SemVer format -> https://semver.org
-pluginVersion = 2.0.5
+pluginVersion = 2.0.6
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 223

--- a/src/main/kotlin/com/jfrog/conan/clion/toolWindow/MainActionToolbar.kt
+++ b/src/main/kotlin/com/jfrog/conan/clion/toolWindow/MainActionToolbar.kt
@@ -24,6 +24,10 @@ class MainActionToolbar(val project: Project) {
                 ConanExecutableDialogWrapper(project).showAndGet()
                 CMake(project).handleAdvancedSettings()
             }
+
+            override fun getActionUpdateThread(): ActionUpdateThread {
+                return ActionUpdateThread.EDT
+            }
         }
     }
 
@@ -39,6 +43,10 @@ class MainActionToolbar(val project: Project) {
             override fun update(e: AnActionEvent) {
                 e.presentation.isEnabled = conanService.isPluginConfigured()
                 super.update(e)
+            }
+
+            override fun getActionUpdateThread(): ActionUpdateThread {
+                return ActionUpdateThread.EDT
             }
         }
     }
@@ -56,6 +64,10 @@ class MainActionToolbar(val project: Project) {
             override fun update(e: AnActionEvent) {
                 e.presentation.isEnabled = conanService.isPluginConfigured()
                 super.update(e)
+            }
+
+            override fun getActionUpdateThread(): ActionUpdateThread {
+                return ActionUpdateThread.EDT
             }
         }
     }


### PR DESCRIPTION
Fixing warnings about deprecated use:

```
com.intellij.diagnostic.PluginException: `ActionUpdateThread.OLD_EDT` is deprecated and going to be removed soon. 'com.jfrog.conan.clion.toolWindow.MainActionToolbar$getShowUsedPackagesAction$1' must override `getActionUpdateThread()` and chose EDT or BGT. See ActionUpdateThread javadoc. [Plugin: com.jfrog.conan.clion]
	at com.intellij.diagnostic.PluginProblemReporterImpl.createPluginExceptionByClass(PluginProblemReporterImpl.java:23)
	at com.intellij.diagnostic.PluginException.createByClass(PluginException.java:90)
	at com.intellij.diagnostic.PluginException.reportDeprecatedUsage(PluginException.java:125)
	at com.intellij.openapi.actionSystem.ActionUpdateThreadAware.getActionUpdateThread(ActionUpdateThreadAware.java:21)
	at com.intellij.openapi.actionSystem.AnAction.getActionUpdateThread(AnAction.java:201)
```

![image](https://github.com/user-attachments/assets/ee8273bf-3ce5-42fc-91e1-4b09abcc960f)
