### PR TITLE
Unset untilBuild to not have an upper compatibility limit

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -86,7 +86,7 @@ intellijPlatform {
 
         ideaVersion {
             sinceBuild = providers.gradleProperty("pluginSinceBuild")
-            untilBuild = providers.gradleProperty("pluginUntilBuild")
+            untilBuild = provider { null }
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,6 @@ pluginVersion = 2.0.8
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 241
-pluginUntilBuild = 243.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = CL


### PR DESCRIPTION
CLion IDE version (2025.1) is about to be released and it will break users, better to remove the upper limit for compatibility.

As specified [in the docs ](https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-extension.html?_gl=1*frpmdp*_gcl_au*MTU3ODA1ODM0OC4xNzM2NDk5ODgx*FPAU*MTU3ODA1ODM0OC4xNzM2NDk5ODgx*_ga*MjA1MjEyNTk1Ni4xNzM2NDk5ODc5*_ga_9J976DJZ68*MTczNzAxMDY3Ni4zLjEuMTczNzAxMDcxNS4yMS4wLjA.#intellijPlatform-pluginConfiguration-ideaVersion-untilBuild):

> An undefined value signifies compatibility with all IDEs starting from the version mentioned in since-build, including potential future builds that may cause compatibility issues.

