### PR TITLE
Fix tool window crash on recent CLion versions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+- Fix "Nothing to show" tool window crash on recent CLion versions where JCEF was split into its own bundled module
+
 ## [2.0.10] - 2025-03-28
 
 - Add "Scan Vulnerabilities" tab

--- a/src/main/kotlin/com/jfrog/conan/clion/toolWindow/AuditPanel.kt
+++ b/src/main/kotlin/com/jfrog/conan/clion/toolWindow/AuditPanel.kt
@@ -2,25 +2,32 @@ package com.jfrog.conan.clion.toolWindow
 
 import com.intellij.ide.ui.LafManager
 import com.intellij.openapi.project.Project
+import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.jcef.JBCefApp
 import com.intellij.ui.jcef.JCEFHtmlPanel
+import com.jfrog.conan.clion.bundles.UIBundle
 import java.awt.Color
 import javax.swing.JComponent
+import javax.swing.SwingConstants
 import javax.swing.SwingUtilities
 
 class AuditPanel(val project: Project) {
-    private val htmlPanel = JCEFHtmlPanel(null).apply {
-        loadHTML("")
-        setOpenLinksInExternalBrowser(true)
-    }.also { htmlPanel ->
-        val cefBrowser = htmlPanel.cefBrowser
-        cefBrowser.uiComponent.addMouseWheelListener { e ->
-            val scrollPane = SwingUtilities.getAncestorOfClass(JBScrollPane::class.java, e.component) as? JBScrollPane
-            scrollPane?.dispatchEvent(SwingUtilities.convertMouseEvent(e.component, e, scrollPane))
+    private val htmlPanel: JCEFHtmlPanel? = if (JBCefApp.isSupported()) {
+        JCEFHtmlPanel(null).apply {
+            loadHTML("")
+            setOpenLinksInExternalBrowser(true)
+        }.also { htmlPanel ->
+            val cefBrowser = htmlPanel.cefBrowser
+            cefBrowser.uiComponent.addMouseWheelListener { e ->
+                val scrollPane = SwingUtilities.getAncestorOfClass(JBScrollPane::class.java, e.component) as? JBScrollPane
+                scrollPane?.dispatchEvent(SwingUtilities.convertMouseEvent(e.component, e, scrollPane))
+            }
         }
-    }
+    } else null
 
     fun updateContent(libraryName: String, version: String) {
+        val panel = htmlPanel ?: return
         val themeStyles = generateThemeStyles()
         val html = """
             <html>
@@ -73,11 +80,12 @@ conan audit scan --requires=${libraryName}/${version}
             </body>
             </html>
         """.trimIndent()
-        htmlPanel.loadHTML(html)
+        panel.loadHTML(html)
     }
 
     // Returns the underlying component for UI integration
-    fun getComponent(): JComponent = htmlPanel.component
+    fun getComponent(): JComponent =
+        htmlPanel?.component ?: JBLabel(UIBundle.message("library.description.jcef.unavailable"), SwingConstants.CENTER)
 
     private fun generateThemeStyles(): String {
         val themeScheme = LafManager.getInstance().currentUIThemeLookAndFeel

--- a/src/main/kotlin/com/jfrog/conan/clion/toolWindow/ReadmePanel.kt
+++ b/src/main/kotlin/com/jfrog/conan/clion/toolWindow/ReadmePanel.kt
@@ -3,25 +3,31 @@ package com.jfrog.conan.clion.toolWindow
 import com.intellij.ide.ui.LafManager
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
+import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.jcef.JBCefApp
 import com.intellij.ui.jcef.JCEFHtmlPanel
+import com.jfrog.conan.clion.bundles.UIBundle
 import com.jfrog.conan.clion.services.ConanService
 import java.awt.Color
 import javax.swing.JComponent
+import javax.swing.SwingConstants
 import javax.swing.SwingUtilities
 
 
 class ReadmePanel(val project: Project) {
-    private val htmlPanel = JCEFHtmlPanel(null).apply {
-        loadHTML("")
-        setOpenLinksInExternalBrowser(true)
-    }.also { htmlPanel ->
-        val cefBrowser = htmlPanel.cefBrowser
-        cefBrowser.uiComponent.addMouseWheelListener { e ->
-            val scrollPane = SwingUtilities.getAncestorOfClass(JBScrollPane::class.java, e.component) as? JBScrollPane
-            scrollPane?.dispatchEvent(SwingUtilities.convertMouseEvent(e.component, e, scrollPane))
+    private val htmlPanel: JCEFHtmlPanel? = if (JBCefApp.isSupported()) {
+        JCEFHtmlPanel(null).apply {
+            loadHTML("")
+            setOpenLinksInExternalBrowser(true)
+        }.also { htmlPanel ->
+            val cefBrowser = htmlPanel.cefBrowser
+            cefBrowser.uiComponent.addMouseWheelListener { e ->
+                val scrollPane = SwingUtilities.getAncestorOfClass(JBScrollPane::class.java, e.component) as? JBScrollPane
+                scrollPane?.dispatchEvent(SwingUtilities.convertMouseEvent(e.component, e, scrollPane))
+            }
         }
-    }
+    } else null
 
     private val targetsDataAsText = project.service<ConanService>().getTargetDataText()
     private val libraryData = project.service<ConanService>().getTargetData()
@@ -158,7 +164,11 @@ class ReadmePanel(val project: Project) {
     }
 
     fun getHTMLPackageInfo(name: String): JComponent {
-        htmlPanel.loadHTML(getHtml(name))
-        return htmlPanel.component
+        val panel = htmlPanel ?: return jcefUnavailableComponent()
+        panel.loadHTML(getHtml(name))
+        return panel.component
     }
+
+    private fun jcefUnavailableComponent(): JComponent =
+        JBLabel(UIBundle.message("library.description.jcef.unavailable"), SwingConstants.CENTER)
 }

--- a/src/main/kotlin/com/jfrog/conan/clion/toolWindow/UsedPackagesPanel.kt
+++ b/src/main/kotlin/com/jfrog/conan/clion/toolWindow/UsedPackagesPanel.kt
@@ -3,21 +3,27 @@ package com.jfrog.conan.clion.toolWindow
 import com.intellij.ide.ui.LafManager
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.jcef.JBCefApp
 import com.intellij.ui.jcef.JCEFHtmlPanel
+import com.jfrog.conan.clion.bundles.UIBundle
 import com.jfrog.conan.clion.models.LibraryData
 import com.jfrog.conan.clion.services.ConanService
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import java.awt.Color
 import javax.swing.JComponent
+import javax.swing.SwingConstants
 
 
 // FIXME: refactor to remove duplicate code from ReadmePanel
 class UsedPackagesPanel(val project: Project) {
-    private val htmlPanel = JCEFHtmlPanel(null).apply {
-        loadHTML("")
-        setOpenLinksInExternalBrowser(true)
-    }
+    private val htmlPanel: JCEFHtmlPanel? = if (JBCefApp.isSupported()) {
+        JCEFHtmlPanel(null).apply {
+            loadHTML("")
+            setOpenLinksInExternalBrowser(true)
+        }
+    } else null
 
     private val libraryData = project.service<ConanService>().getTargetData()
 
@@ -159,7 +165,9 @@ class UsedPackagesPanel(val project: Project) {
     }
 
     fun getHTMLUsedPackages(names: List<String>): JComponent {
-        htmlPanel.loadHTML(getHtml(names))
-        return htmlPanel.component
+        val panel = htmlPanel
+            ?: return JBLabel(UIBundle.message("library.description.jcef.unavailable"), SwingConstants.CENTER)
+        panel.loadHTML(getHtml(names))
+        return panel.component
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -19,6 +19,7 @@
 
     <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.modules.clion</depends>
+    <depends optional="true" config-file="withJcef.xml">com.intellij.modules.jcef</depends>
     <resource-bundle>messages.ui</resource-bundle>
     <extensions defaultExtensionNs="com.intellij">
         <toolWindow factoryClass="com.jfrog.conan.clion.toolWindow.ConanWindowFactory"

--- a/src/main/resources/META-INF/withJcef.xml
+++ b/src/main/resources/META-INF/withJcef.xml
@@ -1,0 +1,5 @@
+<idea-plugin>
+    <dependencies>
+        <module name="intellij.platform.ui.jcef"/>
+    </dependencies>
+</idea-plugin>

--- a/src/main/resources/messages/ui.properties
+++ b/src/main/resources/messages/ui.properties
@@ -31,6 +31,7 @@ library.description.button.install=Use in project
 library.description.button.remove=Remove from project
 library.description.combo.disabled=Please, to add another version of the library, first remove the existing one
 library.description.empty=No selection
+library.description.jcef.unavailable=<html>This preview requires the embedded browser (JCEF), which is not available in this IDE installation.</html>
 
 
 toolbar.action.show.dialog.configure=Configure Conan


### PR DESCRIPTION
Closes: https://github.com/conan-io/conan-clion-plugin/issues/251

On recent CLion builds (reproduced on CLion 2026.2), the Conan tool window fails to initialize with:

```
java.lang.NoClassDefFoundError: com/intellij/ui/jcef/JCEFHtmlPanel
Caused by: java.lang.ClassNotFoundException: com.intellij.ui.jcef.JCEFHtmlPanel
```

resulting in the "Nothing to show" empty tool window.

Starting with recent platform versions, JetBrains split `JCEFHtmlPanel` / `JBCefApp` out of the monolithic IDE core into their own bundled plugin (`com.intellij.modules.jcef`), whose classes live in an on-demand content module (`intellij.platform.ui.jcef`) that is **not** loaded automatically, it must be explicitly declared as a dependency.

This plugin never declared that dependency (it didn't need to on older platform versions, where these classes were simply part of the core), so on the newer, modularized platform builds the tool window's classloader can't see `JCEFHtmlPanel` at  all, and the whole window fails to construct.

Changes:

- `plugin.xml`: declare an optional dependency on `com.intellij.modules.jcef`, activating `withJcef.xml` only when that plugin is present.
- `withJcef.xml` (new): declares the actual `intellij.platform.ui.jcef` module dependency, making the JCEF classes visible to the plugin's classloader on IDEs where they exist as a separate module.
- `ReadmePanel`, `AuditPanel`, `UsedPackagesPanel`: guard `JCEFHtmlPanel` construction behind `JBCefApp.isSupported()`, falling back to a simple message panel instead of crashing when JCEF isn't available (covers the #166 scenario, where the class resolves but JCEF fails to initialize).

Since the dependency is declared as `optional`, this doesn't affect older IDEs at all: there JCEF is still part of the core and behaves exactly as before.
